### PR TITLE
Bug 578660 - Docker terminal gets InaccessibleObjectException

### DIFF
--- a/containers/org.eclipse.linuxtools.docker-feature/p2.inf
+++ b/containers/org.eclipse.linuxtools.docker-feature/p2.inf
@@ -2,4 +2,9 @@ instructions.configure=\
 org.eclipse.equinox.p2.touchpoint.eclipse.removeRepository(location:http${#58}//download.eclipse.org/linuxtools/updates-docker-nightly,type:0); \
 org.eclipse.equinox.p2.touchpoint.eclipse.removeRepository(location:http${#58}//download.eclipse.org/linuxtools/updates-docker-nightly,type:1); \
 org.eclipse.equinox.p2.touchpoint.eclipse.addRepository(location:https${#58}//download.eclipse.org/linuxtools/updates-docker-nightly,type:0,name:Linux Tools Docker Tooling,enabled:false); \
-org.eclipse.equinox.p2.touchpoint.eclipse.addRepository(location:https${#58}//download.eclipse.org/linuxtools/updates-docker-nightly,type:1,name:Linux Tools Docker Tooling,enabled:false); 
+org.eclipse.equinox.p2.touchpoint.eclipse.addRepository(location:https${#58}//download.eclipse.org/linuxtools/updates-docker-nightly,type:1,name:Linux Tools Docker Tooling,enabled:false); \
+org.eclipse.equinox.p2.touchpoint.eclipse.addJvmArg(jvmArg:--add-opens=java.base/java.io=ALL-UNNAMED); \
+org.eclipse.equinox.p2.touchpoint.eclipse.addJvmArg(jvmArg:--add-opens=java.base/sun.nio.ch=ALL-UNNAMED); \
+org.eclipse.equinox.p2.touchpoint.eclipse.addJvmArg(jvmArg:--add-opens=java.base/java.net=ALL-UNNAMED); \
+org.eclipse.equinox.p2.touchpoint.eclipse.addJvmArg(jvmArg:--add-opens=java.base/sun.security.ssl=ALL-UNNAMED);
+


### PR DESCRIPTION
- use addJvmArgs touchpoint to add --add-opens statements to eclipse.ini via
  the p2.inf file for the Docker tooling feature