### PR TITLE
Bug 578660 - Docker terminal gets InaccessibleObjectException

### DIFF
--- a/containers/org.eclipse.linuxtools.docker-feature/p2.inf
+++ b/containers/org.eclipse.linuxtools.docker-feature/p2.inf
@@ -3,8 +3,12 @@ org.eclipse.equinox.p2.touchpoint.eclipse.removeRepository(location:http${#58}//
 org.eclipse.equinox.p2.touchpoint.eclipse.removeRepository(location:http${#58}//download.eclipse.org/linuxtools/updates-docker-nightly,type:1); \
 org.eclipse.equinox.p2.touchpoint.eclipse.addRepository(location:https${#58}//download.eclipse.org/linuxtools/updates-docker-nightly,type:0,name:Linux Tools Docker Tooling,enabled:false); \
 org.eclipse.equinox.p2.touchpoint.eclipse.addRepository(location:https${#58}//download.eclipse.org/linuxtools/updates-docker-nightly,type:1,name:Linux Tools Docker Tooling,enabled:false); \
+org.eclipse.equinox.p2.touchpoint.eclipse.removeJvmArg(jvmArg:--add-opens=java.base/java.io=ALL-UNNAMED); \
 org.eclipse.equinox.p2.touchpoint.eclipse.addJvmArg(jvmArg:--add-opens=java.base/java.io=ALL-UNNAMED); \
+org.eclipse.equinox.p2.touchpoint.eclipse.removeJvmArg(jvmArg:--add-opens=java.base/sun.nio.ch=ALL-UNNAMED); \
 org.eclipse.equinox.p2.touchpoint.eclipse.addJvmArg(jvmArg:--add-opens=java.base/sun.nio.ch=ALL-UNNAMED); \
+org.eclipse.equinox.p2.touchpoint.eclipse.removeJvmArg(jvmArg:--add-opens=java.base/java.net=ALL-UNNAMED); \
 org.eclipse.equinox.p2.touchpoint.eclipse.addJvmArg(jvmArg:--add-opens=java.base/java.net=ALL-UNNAMED); \
+org.eclipse.equinox.p2.touchpoint.eclipse.removeJvmArg(jvmArg:--add-opens=java.base/sun.security.ssl=ALL-UNNAMED); \
 org.eclipse.equinox.p2.touchpoint.eclipse.addJvmArg(jvmArg:--add-opens=java.base/sun.security.ssl=ALL-UNNAMED);
 


### PR DESCRIPTION
- add removeJvmArg statements in Docker Tooling feature p2.inf so new
  addJvmArg touchpoint statements are not duplicated when updating