### PR TITLE
Update Docker LS to 0.8.0

### DIFF
--- a/containers/org.eclipse.linuxtools.docker.editor.ls/pom.xml
+++ b/containers/org.eclipse.linuxtools.docker.editor.ls/pom.xml
@@ -40,7 +40,7 @@
 							<arguments>
 								<arg>install</arg>
 								<arg>--no-bin-links</arg>
-								<arg>dockerfile-language-server-nodejs@0.7.3</arg>
+								<arg>dockerfile-language-server-nodejs@0.8.0</arg>
 							</arguments>
 							<workingDirectory>language-server/</workingDirectory>
 						</configuration>


### PR DESCRIPTION
Licensecheck doesn't complain.
Changelog:
https://github.com/rcjsuen/dockerfile-language-server-nodejs/blob/master/CHANGELOG.md#080---2022-01-22

Signed-off-by: Alexander Kurtakov <akurtako@redhat.com>