### PR TITLE
ArrayIndexOutOfBoundsException thrown while parsing devhelp2 files

### DIFF
--- a/libhover/org.eclipse.linuxtools.cdt.libhover.devhelp/src/org/eclipse/linuxtools/internal/cdt/libhover/devhelp/ParseDevHelp.java
+++ b/libhover/org.eclipse.linuxtools.cdt.libhover.devhelp/src/org/eclipse/linuxtools/internal/cdt/libhover/devhelp/ParseDevHelp.java
@@ -459,6 +459,9 @@ public class ParseDevHelp {
                                     && !nameValue.contains("\"")) { //$NON-NLS-1$
                                 String linkValue = link.getNodeValue();
                                 String[] linkParts = linkValue.split("#"); //$NON-NLS-1$
+                                if (linkParts.length < 2) {
+                                	return;
+                                }
                                 // Check if the file referred to by the link has been seen before
                                 // If not, create a new function list for it
                                 HashMap<String, String> funcMap = files.get(linkParts[0]);
@@ -494,6 +497,9 @@ public class ParseDevHelp {
                                             && !nameValue.contains("\"")) { //$NON-NLS-1$
                                         String linkValue = link.getNodeValue();
                                         String[] linkParts = linkValue.split("#"); //$NON-NLS-1$
+                                        if (linkParts.length < 2) {
+                                        	return;
+                                        }
                                         // Check to see if the file referred to by the link has been seen before
                                         // If not, create a new function list for it
                                         HashMap<String, String> funcMap = files.get(linkParts[0]);


### PR DESCRIPTION
- newer format devhelp2 files do not follow the format supported by
  ParseDevHelp
- if no anchors for methods/functions, then bail immediately