### PR TITLE
Bug 563169 - [syntax highlighting] Fails for Dockerfile.something

### DIFF
--- a/containers/org.eclipse.linuxtools.docker.editor.ls/META-INF/MANIFEST.MF
+++ b/containers/org.eclipse.linuxtools.docker.editor.ls/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Dockerfile Language Server Client
 Bundle-SymbolicName: org.eclipse.linuxtools.docker.editor.ls;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.0.1.qualifier
 Bundle-Vendor: Eclipse
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy

--- a/containers/org.eclipse.linuxtools.docker.editor.ls/plugin.xml
+++ b/containers/org.eclipse.linuxtools.docker.editor.ls/plugin.xml
@@ -27,6 +27,7 @@
             base-type="org.eclipse.core.runtime.text"
             file-extensions="Dockerfile,dockerfile"
             file-names="Dockerfile"
+            file-patterns="Dockerfile.*"
             id="org.eclipse.linuxtools.docker.editor.ls"
             name="Dockerfile"
             priority="normal">

--- a/containers/org.eclipse.linuxtools.docker.editor.ls/pom.xml
+++ b/containers/org.eclipse.linuxtools.docker.editor.ls/pom.xml
@@ -7,7 +7,7 @@
 		<version>5.7.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.eclipse.linuxtools.docker.editor.ls</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.0.1-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
     <build>


### PR DESCRIPTION
- add file-patterns specifier for dockerfile ls editor content types
- bump docker ls editor version