### PR TITLE
Use WWD snapshot repo in target platform

### DIFF
--- a/releng/org.eclipse.linuxtools.target/linuxtools-e4.25.target
+++ b/releng/org.eclipse.linuxtools.target/linuxtools-e4.25.target
@@ -73,7 +73,11 @@
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.license.feature.group" version="0.0.0"/>
-<repository location="https://download.eclipse.org/cbi/updates/license"/>
+<repository location="https://download.eclipse.org/cbi/updates/license"/>https://download.eclipse.org/wildwebdeveloper/snapshots/
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.wildwebdeveloper.embedder.node.feature.feature.group" version="0.0.0"/>
+<repository location="https://download.eclipse.org/wildwebdeveloper/snapshots/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.tm.terminal.feature.feature.group" version="0.0.0"/>
@@ -92,7 +96,6 @@
 <unit id="org.eclipse.zest.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.lsp4e" version="0.0.0"/>
 <unit id="org.eclipse.tm4e.feature.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.wildwebdeveloper.embedder.node.feature.feature.group" version="0.0.0"/>
 <repository location="https://download.eclipse.org/releases/2022-06/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
@@ -106,7 +109,7 @@
 <repository location="https://download.eclipse.org/swtchart/integration/REL-0.13.0/repository"/>
 </location>
 </locations>
-<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 <launcherArgs>
 <vmArgs>-Xms40m
 -Xmx512M</vmArgs>


### PR DESCRIPTION
Needed to pick
https://github.com/eclipse/wildwebdeveloper/commit/8ab686a9e9cb0fb3e0b45c137e6ce6a4321f382d
which fixes issue claiming that Node.js 16 is not supported version.