### PR TITLE
Move Docker editor plugin to Java 17

### DIFF
--- a/containers/org.eclipse.linuxtools.docker.editor.ls.tests/.classpath
+++ b/containers/org.eclipse.linuxtools.docker.editor.ls.tests/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src">
 		<attributes>

--- a/containers/org.eclipse.linuxtools.docker.editor.ls.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/containers/org.eclipse.linuxtools.docker.editor.ls.tests/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,8 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
-org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.compliance=17
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate
@@ -11,4 +11,4 @@ org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.source=17

--- a/containers/org.eclipse.linuxtools.docker.editor.ls.tests/META-INF/MANIFEST.MF
+++ b/containers/org.eclipse.linuxtools.docker.editor.ls.tests/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.linuxtools.docker.editor.ls.tests
 Bundle-Version: 1.0.0.qualifier
 Fragment-Host: org.eclipse.linuxtools.docker.editor.ls
 Automatic-Module-Name: org.eclipse.linuxtools.docker.editor.ls.tests
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.resources,
  org.junit,
  org.eclipse.ui.workbench,

--- a/containers/org.eclipse.linuxtools.docker.editor.ls.tests/src/org/eclipse/linuxtools/docker/editor/ls/tests/TestLanguageServers.java
+++ b/containers/org.eclipse.linuxtools.docker.editor.ls.tests/src/org/eclipse/linuxtools/docker/editor/ls/tests/TestLanguageServers.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Red Hat Inc. and others.
+ * Copyright (c) 2019, 2022 Red Hat Inc. and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -76,15 +76,13 @@ public class TestLanguageServers {
 		ITextEditor editor = (ITextEditor) IDE
 				.openEditor(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), file, "org.eclipse.ui.genericeditor.GenericEditor");
 		editor.getDocumentProvider().getDocument(editor.getEditorInput()).set("MAINTAINER alex");
-		assertTrue("Diagnostic not published", new DisplayHelper() {
-			@Override
-			protected boolean condition() {
-				try {
-					return file.findMarkers("org.eclipse.lsp4e.diagnostic", true, IResource.DEPTH_ZERO).length != 0;
-				} catch (CoreException e) {
-					return false;
-				}
-			}
-		}.waitForCondition(PlatformUI.getWorkbench().getDisplay(), 5000));
+		assertTrue("Diagnostic not published",
+				DisplayHelper.waitForCondition(PlatformUI.getWorkbench().getDisplay(), 5000, () -> {
+					try {
+						return file.findMarkers("org.eclipse.lsp4e.diagnostic", true, IResource.DEPTH_ZERO).length != 0;
+					} catch (CoreException e) {
+						return false;
+					}
+				}));
 	}
 }

--- a/containers/org.eclipse.linuxtools.docker.editor.ls/.classpath
+++ b/containers/org.eclipse.linuxtools.docker.editor.ls/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="target/classes"/>

--- a/containers/org.eclipse.linuxtools.docker.editor.ls/.settings/org.eclipse.jdt.core.prefs
+++ b/containers/org.eclipse.linuxtools.docker.editor.ls/.settings/org.eclipse.jdt.core.prefs
@@ -1,10 +1,10 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
-org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.source=17

--- a/containers/org.eclipse.linuxtools.docker.editor.ls/META-INF/MANIFEST.MF
+++ b/containers/org.eclipse.linuxtools.docker.editor.ls/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Dockerfile Language Server Client
 Bundle-SymbolicName: org.eclipse.linuxtools.docker.editor.ls;singleton:=true
 Bundle-Version: 1.0.1.qualifier
 Bundle-Vendor: Eclipse
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.lsp4e;bundle-version="0.11.0",
  org.eclipse.ui.genericeditor;bundle-version="1.0.0",

--- a/containers/org.eclipse.linuxtools.docker.editor.ls/src/org/eclipse/linuxtools/docker/editor/ls/DockerfileLanguageServer.java
+++ b/containers/org.eclipse.linuxtools.docker.editor.ls/src/org/eclipse/linuxtools/docker/editor/ls/DockerfileLanguageServer.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc. and others.
- * 
+ * Copyright (c) 2017, 2022 Red Hat Inc. and others.
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -20,13 +20,13 @@ import org.eclipse.lsp4e.server.ProcessStreamConnectionProvider;
 
 public class DockerfileLanguageServer extends ProcessStreamConnectionProvider {
 
-	final static String PATH = "/language-server/node_modules/dockerfile-language-server-nodejs/lib/server.js"; //$NON-NLS-1$
+	static final String PATH = "/language-server/node_modules/dockerfile-language-server-nodejs/lib/server.js"; //$NON-NLS-1$
 
 	public DockerfileLanguageServer() {
-		List<String> command = new ArrayList<> ();
+		List<String> command = new ArrayList<>();
 		try {
 			URL url = FileLocator.toFileURL(getClass().getResource(PATH));
-			String resourcePath = new File (url.getPath()).getAbsolutePath();
+			String resourcePath = new File(url.getPath()).getAbsolutePath();
 			String nodePath = InitializeLaunchConfigurations.getNodeJsLocation();
 			if (nodePath != null) {
 				command.add(nodePath);

--- a/containers/org.eclipse.linuxtools.docker.editor.ls/src/org/eclipse/linuxtools/docker/editor/ls/InitializeLaunchConfigurations.java
+++ b/containers/org.eclipse.linuxtools.docker.editor.ls/src/org/eclipse/linuxtools/docker/editor/ls/InitializeLaunchConfigurations.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 Red Hat Inc. and others.
+ * Copyright (c) 2016, 2022 Red Hat Inc. and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -33,7 +33,7 @@ public class InitializeLaunchConfigurations {
 		}
 
 		String res = null;
-		String[] command = new String[] { "/bin/bash", "-c", "which node" };
+		String[] command = { "/bin/bash", "-c", "which node" };
 		if (Platform.getOS().equals(Platform.OS_WIN32)) {
 			command = new String[] { "cmd", "/c", "where node" };
 		}


### PR DESCRIPTION
It relies on WWD and TM4E and both have moved to Java 17 for September
release.