### PR TITLE
Docker Pull: Handle cancellation

### DIFF
--- a/containers/org.eclipse.linuxtools.docker.core/src/org/eclipse/linuxtools/docker/core/DockerOperationCancelledException.java
+++ b/containers/org.eclipse.linuxtools.docker.core/src/org/eclipse/linuxtools/docker/core/DockerOperationCancelledException.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Mathema
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Mathema - Initial Contribution
+ *******************************************************************************/
+
+package org.eclipse.linuxtools.docker.core;
+
+import org.eclipse.linuxtools.internal.docker.core.DockerMessages;
+
+/**
+ * The operation was cancelled by the user
+ *
+ * @since 5.8
+ */
+public class DockerOperationCancelledException extends DockerException {
+
+	public DockerOperationCancelledException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public DockerOperationCancelledException(String message) {
+		super(message);
+	}
+
+	public DockerOperationCancelledException(Throwable e) {
+		super(e);
+	}
+
+	public DockerOperationCancelledException() {
+		super(DockerMessages
+				.getString("DockerOperationCancelledException_Message"));
+	}
+
+	private static final long serialVersionUID = -719975300488986809L;
+}

--- a/containers/org.eclipse.linuxtools.docker.core/src/org/eclipse/linuxtools/docker/core/IDockerConnection.java
+++ b/containers/org.eclipse.linuxtools.docker.core/src/org/eclipse/linuxtools/docker/core/IDockerConnection.java
@@ -219,10 +219,44 @@ public interface IDockerConnection {
 	 */
 	List<IDockerImage> listImages() throws DockerException;
 
+	/**
+	 * Pull an image from the registry
+	 *
+	 * @param id
+	 *            The image to pull
+	 * @param handler
+	 *            A progress handler that gets called on Progress
+	 * @throws DockerOperationCancelledException
+	 *             If the progress handler throws an
+	 *             {@link DockerOperationCancelledException}. Note that
+	 *             DockerOperationCancelledException is a child of
+	 *             DockerException.
+	 * @throws DockerException
+	 *             In case of an error
+	 * @throws InterruptedException
+	 *             If the thread is interrupted
+	 */
 	void pullImage(String id, IDockerProgressHandler handler)
 			throws DockerException, InterruptedException;
 
 	/**
+	 * Pull an image from the registry
+	 *
+	 * @param id
+	 *            The image to pull
+	 * @param info
+	 *            Account information needed to log into the registry
+	 * @param handler
+	 *            A progress handler that gets called on Progress
+	 * @throws DockerOperationCancelledException
+	 *             If the progress handler throws an
+	 *             {@link DockerOperationCancelledException}. Note that
+	 *             DockerOperationCancelledException is a child of
+	 *             DockerException.
+	 * @throws DockerException
+	 *             In case of an error
+	 * @throws InterruptedException
+	 *             If the thread is interrupted
 	 * @since 2.0
 	 */
 	void pullImage(String id, IRegistryAccount info,

--- a/containers/org.eclipse.linuxtools.docker.core/src/org/eclipse/linuxtools/docker/core/IDockerConnection4.java
+++ b/containers/org.eclipse.linuxtools.docker.core/src/org/eclipse/linuxtools/docker/core/IDockerConnection4.java
@@ -1,0 +1,24 @@
+package org.eclipse.linuxtools.docker.core;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+
+/**
+ * @since 5.8
+ */
+public interface IDockerConnection4
+		extends IDockerConnection, IDockerConnection2, IDockerConnection3 {
+
+	/**
+	 * Get the default progress handler for pulling images.
+	 *
+	 * @param image
+	 *            name of image being pulled
+	 * @param monitor
+	 *            A Jobs progress monitor. If it is cancelled the pull will be
+	 *            cancelled, too.
+	 * @return progress handler
+	 * @since 5.7
+	 */
+	IDockerProgressHandler getDefaultPullImageProgressHandler(String image,
+			IProgressMonitor monitor);
+}

--- a/containers/org.eclipse.linuxtools.docker.core/src/org/eclipse/linuxtools/docker/core/IDockerProgressHandler.java
+++ b/containers/org.eclipse.linuxtools.docker.core/src/org/eclipse/linuxtools/docker/core/IDockerProgressHandler.java
@@ -14,6 +14,17 @@ package org.eclipse.linuxtools.docker.core;
 
 public interface IDockerProgressHandler {
 
+	/**
+	 * To cancel the the current operation a
+	 * {@link DockerOperationCancelledException} should be thrown. This is
+	 * currently only supported by pullImage().
+	 *
+	 * @param message
+	 *            The progress message
+	 * @throws DockerException
+	 *             If an exception is thrown the current operation is normally
+	 *             terminated
+	 */
 	void processMessage(IDockerProgressMessage message) throws DockerException;
 
 }

--- a/containers/org.eclipse.linuxtools.docker.core/src/org/eclipse/linuxtools/internal/docker/core/DefaultImagePullProgressHandler.java
+++ b/containers/org.eclipse.linuxtools.docker.core/src/org/eclipse/linuxtools/internal/docker/core/DefaultImagePullProgressHandler.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2014, 2018 Red Hat.
- * 
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -12,12 +12,14 @@
  *******************************************************************************/
 package org.eclipse.linuxtools.internal.docker.core;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
+import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.linuxtools.docker.core.DockerException;
 import org.eclipse.linuxtools.docker.core.DockerImagePullFailedException;
+import org.eclipse.linuxtools.docker.core.DockerOperationCancelledException;
 import org.eclipse.linuxtools.docker.core.IDockerConnection;
 import org.eclipse.linuxtools.docker.core.IDockerProgressDetail;
 import org.eclipse.linuxtools.docker.core.IDockerProgressHandler;
@@ -40,173 +42,214 @@ public class DefaultImagePullProgressHandler implements IDockerProgressHandler {
 
 	private String image;
 	private DockerConnection connection;
+	private IProgressMonitor monitor;
+	private boolean cancelled = false;
 
-	private Map<String, ProgressJob> progressJobs = new HashMap<>();
+	private Map<String, ProgressJob> progressJobs = new ConcurrentHashMap<>();
 
-	public DefaultImagePullProgressHandler(IDockerConnection connection, String image) {
+	public DefaultImagePullProgressHandler(IDockerConnection connection,
+			String image, IProgressMonitor monitor) {
 		this.image = image;
 		this.connection = (DockerConnection) connection;
+		this.monitor = monitor;
+	}
+
+	/**
+	 * The first exception will be returned. Thus throwing
+	 * DockerOperationCancelledException after DockerImagePullFailedException
+	 * will just ensure that any other threads are cancelled.
+	 *
+	 * @throws DockerOperationCancelledException
+	 * @throws DockerImagePullFailedException
+	 */
+	private void handleCancellation(IDockerProgressMessage message)
+			throws DockerOperationCancelledException,
+			DockerImagePullFailedException {
+
+		// Clean up children. They are either OK, or cancelled - if one of them
+		// is cancelled - the whole operation needs to be cancelled
+		for (var j : progressJobs.entrySet()) {
+			var res = j.getValue().getResult();
+			if (res != null) {
+				progressJobs.remove(j.getKey());
+				if (!res.isOK()) {
+					cancelled = true;
+				}
+			}
+		}
+
+		// If a monitor was passed check whether that was cancelled.
+		if (monitor != null && monitor.isCanceled()) {
+			cancelled = true;
+		}
+
+		if (message.error() != null)
+			cancelled = true;
+
+		if (cancelled) {
+			// Cancel all the other jobs
+			for (var j : progressJobs.values()) {
+				j.cancel();
+			}
+			if (message.error() != null) {
+				throw new DockerImagePullFailedException(image,
+						message.error());
+			} else {
+				throw new DockerOperationCancelledException();
+			}
+		}
 	}
 
 	@Override
 	public void processMessage(IDockerProgressMessage message)
 			throws DockerException {
-		if (message.error() != null) {
-			stopAllJobs();
-			throw new DockerImagePullFailedException(image, message.error());
-		}
+
+		// This will throw if anything was cancelled.
+		handleCancellation(message);
+
 		String id = message.id();
-		if (id != null) {
-			ProgressJob p = progressJobs.get(id);
-			if (p == null) {
-				String status = message.status();
-				if (status.contains(DockerMessages.getString(IMAGE_PULLING))) {
-					// do nothing
-				} else if (status
-						.equals(DockerMessages.getString(IMAGE_DOWNLOAD_COMPLETE))
-						|| status.contains(DockerMessages
-								.getString(IMAGE_DOWNLOADING_ALREADY_EXISTS))
-						|| status.contains(DockerMessages
-								.getString(IMAGE_DOWNLOADING_VERIFIED))
-						|| status.contains(DockerMessages
-								.getString(IMAGE_VERIFYING_CHECKSUM))
-						|| status.equals(
-								DockerMessages.getString(IMAGE_PULL_COMPLETE))) {
-					// an image is fully loaded, update the image list
-					connection.getImages(true);
-				} else if (status
-						.startsWith(DockerMessages.getString(IMAGE_DOWNLOADING))) {
-					IDockerProgressDetail detail = message.progressDetail();
-					if (detail == null || detail.total() == 0) {
-						// We have a new extraction in progress with no
-						// details of what the total should be. Track it.
-						ProgressJob2 newJob = new ProgressJob2(
-								DockerMessages.getFormattedString(
-										IMAGE_DOWNLOADING_JOBNAME, image),
-								DockerMessages.getFormattedString(
-										IMAGE_DOWNLOADING_IMAGE, id));
-						// job.setUser(false) will show all pull job (one per
-						// image layer) in the progress
-						// view but not in multiple dialog
-						newJob.setUser(false);
-						newJob.setPriority(Job.LONG);
-						newJob.schedule();
-						progressJobs.put(id, newJob);
+		if (id == null)
+			return; // Nothing to do
 
-					} else {
-						// We have a new download in progress and it
-						// provides us with a total so we can calculate
-						// percentage done. Track it.
-						ProgressJob newJob = new ProgressJob(
-								DockerMessages.getFormattedString(
-										IMAGE_DOWNLOADING_JOBNAME, image),
-								DockerMessages.getFormattedString(
-										IMAGE_DOWNLOADING_IMAGE, id));
-						// job.setUser(false) will show all pull job (one per
-						// image layer) in the progress
-						// view but not in multiple dialog
-						newJob.setUser(false);
-						newJob.setPriority(Job.LONG);
-						newJob.schedule();
-						progressJobs.put(id, newJob);
-					}
-				} else if (status.startsWith(
-						DockerMessages.getString(IMAGE_EXTRACTING))) {
-					IDockerProgressDetail detail = message.progressDetail();
-					if (detail == null || detail.total() == 0) {
-						// We have a new extraction in progress with no
-						// details of what the total should be. Track it.
-						ProgressJob2 newJob = new ProgressJob2(
-								DockerMessages.getFormattedString(
-										IMAGE_EXTRACTING_JOBNAME, image),
-								DockerMessages.getFormattedString(
-										IMAGE_EXTRACTING_IMAGE, id));
-						// job.setUser(false) will show all pull job (one per
-						// image layer) in the progress
-						// view but not in multiple dialog
-						newJob.setUser(false);
-						newJob.setPriority(Job.LONG);
-						newJob.schedule();
-						progressJobs.put(id, newJob);
-					} else {
-						// We have a new extraction in progress and it
-						// provides us with a total so we can calculate
-						// percentage done. Track it.
-						ProgressJob newJob = new ProgressJob(
-								DockerMessages.getFormattedString(
-										IMAGE_EXTRACTING_JOBNAME, image),
-								DockerMessages.getFormattedString(
-										IMAGE_EXTRACTING_IMAGE, id));
-						// job.setUser(false) will show all pull job (one per
-						// image
-						// layer) in the progress
-						// view but not in multiple dialog
-						newJob.setUser(false);
-						newJob.setPriority(Job.LONG);
-						newJob.schedule();
-						progressJobs.put(id, newJob);
+		ProgressJob p = progressJobs.get(id);
+		if (p == null) {
+			String status = message.status();
+			if (status.contains(DockerMessages.getString(IMAGE_PULLING))) {
+				// do nothing
+			} else if (status
+					.equals(DockerMessages.getString(IMAGE_DOWNLOAD_COMPLETE))
+					|| status.contains(DockerMessages
+							.getString(IMAGE_DOWNLOADING_ALREADY_EXISTS))
+					|| status.contains(DockerMessages
+							.getString(IMAGE_DOWNLOADING_VERIFIED))
+					|| status.contains(
+							DockerMessages.getString(IMAGE_VERIFYING_CHECKSUM))
+					|| status.equals(
+							DockerMessages.getString(IMAGE_PULL_COMPLETE))) {
+				// an image is fully loaded, update the image list
+				connection.getImages(true);
+			} else if (status
+					.startsWith(DockerMessages.getString(IMAGE_DOWNLOADING))) {
+				IDockerProgressDetail detail = message.progressDetail();
+				if (detail == null || detail.total() == 0) {
+					// We have a new extraction in progress with no
+					// details of what the total should be. Track it.
+					ProgressJob2 newJob = new ProgressJob2(
+							DockerMessages.getFormattedString(
+									IMAGE_DOWNLOADING_JOBNAME, image),
+							DockerMessages.getFormattedString(
+									IMAGE_DOWNLOADING_IMAGE, id));
+					// job.setUser(false) will show all pull job (one per
+					// image layer) in the progress
+					// view but not in multiple dialog
+					newJob.setUser(false);
+					newJob.setPriority(Job.LONG);
+					newJob.schedule();
+					progressJobs.put(id, newJob);
+
+				} else {
+					// We have a new download in progress and it
+					// provides us with a total so we can calculate
+					// percentage done. Track it.
+					ProgressJob newJob = new ProgressJob(
+							DockerMessages.getFormattedString(
+									IMAGE_DOWNLOADING_JOBNAME, image),
+							DockerMessages.getFormattedString(
+									IMAGE_DOWNLOADING_IMAGE, id));
+					// job.setUser(false) will show all pull job (one per
+					// image layer) in the progress
+					// view but not in multiple dialog
+					newJob.setUser(false);
+					newJob.setPriority(Job.LONG);
+					newJob.schedule();
+					progressJobs.put(id, newJob);
+				}
+			} else if (status
+					.startsWith(DockerMessages.getString(IMAGE_EXTRACTING))) {
+				IDockerProgressDetail detail = message.progressDetail();
+				if (detail == null || detail.total() == 0) {
+					// We have a new extraction in progress with no
+					// details of what the total should be. Track it.
+					ProgressJob2 newJob = new ProgressJob2(
+							DockerMessages.getFormattedString(
+									IMAGE_EXTRACTING_JOBNAME, image),
+							DockerMessages.getFormattedString(
+									IMAGE_EXTRACTING_IMAGE, id));
+					// job.setUser(false) will show all pull job (one per
+					// image layer) in the progress
+					// view but not in multiple dialog
+					newJob.setUser(false);
+					newJob.setPriority(Job.LONG);
+					newJob.schedule();
+					progressJobs.put(id, newJob);
+				} else {
+					// We have a new extraction in progress and it
+					// provides us with a total so we can calculate
+					// percentage done. Track it.
+					ProgressJob newJob = new ProgressJob(
+							DockerMessages.getFormattedString(
+									IMAGE_EXTRACTING_JOBNAME, image),
+							DockerMessages.getFormattedString(
+									IMAGE_EXTRACTING_IMAGE, id));
+					// job.setUser(false) will show all pull job (one per
+					// image
+					// layer) in the progress
+					// view but not in multiple dialog
+					newJob.setUser(false);
+					newJob.setPriority(Job.LONG);
+					newJob.schedule();
+					progressJobs.put(id, newJob);
+				}
+			}
+
+		} else {
+			String status = message.status();
+			if (status.equals(DockerMessages.getString(IMAGE_DOWNLOAD_COMPLETE))
+					|| status.contains(DockerMessages
+							.getString(IMAGE_DOWNLOADING_ALREADY_EXISTS))
+					|| status.contains(DockerMessages
+							.getString(IMAGE_DOWNLOADING_VERIFIED))
+					|| status.contains(
+							DockerMessages.getString(IMAGE_VERIFYING_CHECKSUM))
+					|| status.contains(
+							DockerMessages.getString(IMAGE_PULL_COMPLETE))) {
+				// Download or pull is complete for this id so set the job
+				// percentage 100 and
+				// remove the job from list. Removing the job allows
+				// extraction job to be
+				// created after a download is complete.
+				p.setPercentageDone(100);
+				progressJobs.remove(id);
+				connection.getImages(true);
+			} else if (status
+					.startsWith(DockerMessages.getString(IMAGE_DOWNLOADING))) {
+				// Update download progress
+				IDockerProgressDetail detail = message.progressDetail();
+				if (detail != null) {
+					if (p instanceof ProgressJob2) {
+						((ProgressJob2) p).setStatusMessage(message.progress());
+					} else if (detail.current() > 0 && detail.total() > 0) {
+						long percentage = (detail.current() * 100)
+								/ detail.total();
+						p.setPercentageDone((int) percentage);
 					}
 				}
-
-			} else {
-				String status = message.status();
-				if (status.equals(DockerMessages.getString(IMAGE_DOWNLOAD_COMPLETE))
-						|| status.contains(DockerMessages
-								.getString(IMAGE_DOWNLOADING_ALREADY_EXISTS))
-						|| status.contains(DockerMessages
-								.getString(IMAGE_DOWNLOADING_VERIFIED))
-						|| status.contains(DockerMessages
-								.getString(IMAGE_VERIFYING_CHECKSUM))
-						|| status.contains(DockerMessages
-								.getString(IMAGE_PULL_COMPLETE))) {
-					// Download or pull is complete for this id so set the job
-					// percentage 100 and
-					// remove the job from list. Removing the job allows
-					// extraction job to be
-					// created after a download is complete.
-					p.setPercentageDone(100);
-					progressJobs.put(id, null);
-					connection.getImages(true);
-				} else if (status
-						.startsWith(DockerMessages.getString(IMAGE_DOWNLOADING))) {
-					// Update download progress
-					IDockerProgressDetail detail = message.progressDetail();
-					if (detail != null) {
-						if (p instanceof ProgressJob2) {
-							((ProgressJob2) p)
-									.setStatusMessage(message.progress());
-						} else if (detail.current() > 0 && detail.total() > 0) {
-							long percentage = (detail.current() * 100)
-									/ detail.total();
-							p.setPercentageDone((int) percentage);
-						}
-					}
-				} else if (status.startsWith(
-						DockerMessages.getString(IMAGE_EXTRACTING))) {
-					// Update extracting progress
-					IDockerProgressDetail detail = message.progressDetail();
-					if (detail != null) {
-						if (p instanceof ProgressJob2) {
-							((ProgressJob2) p)
-									.setStatusMessage(message.progress());
-						} else if (detail.current() > 0 && detail.total() > 0) {
-							long percentage = (detail.current() * 100)
-									/ detail.total();
-							p.setPercentageDone((int) percentage);
-						}
+			} else if (status
+					.startsWith(DockerMessages.getString(IMAGE_EXTRACTING))) {
+				// Update extracting progress
+				IDockerProgressDetail detail = message.progressDetail();
+				if (detail != null) {
+					if (p instanceof ProgressJob2) {
+						((ProgressJob2) p).setStatusMessage(message.progress());
+					} else if (detail.current() > 0 && detail.total() > 0) {
+						long percentage = (detail.current() * 100)
+								/ detail.total();
+						p.setPercentageDone((int) percentage);
 					}
 				}
 			}
-		}
-	}
 
-	private void stopAllJobs() {
-		for (ProgressJob j : progressJobs.values()) {
-			if (j != null) {
-				j.cancel();
-			}
 		}
-
 	}
 
 }

--- a/containers/org.eclipse.linuxtools.docker.core/src/org/eclipse/linuxtools/internal/docker/core/DockerMessages.properties
+++ b/containers/org.eclipse.linuxtools.docker.core/src/org/eclipse/linuxtools/internal/docker/core/DockerMessages.properties
@@ -37,3 +37,4 @@ ImageBuilding.msg=Building image
 DockerClientVersionTooLow.error=The version of docker client cannot support {0} using a daemon with API version: {1} and higher.
 DockerContainerNotFound.error=Container: {0} could not be found
 DockerStartContainer.error=Error starting command: \"{0}\" for container
+DockerOperationCancelledException_Message=Operation was cancelled by user

--- a/containers/org.eclipse.linuxtools.docker.ui/src/org/eclipse/linuxtools/internal/docker/ui/commands/PullImageCommandHandler.java
+++ b/containers/org.eclipse.linuxtools.docker.ui/src/org/eclipse/linuxtools/internal/docker/ui/commands/PullImageCommandHandler.java
@@ -21,6 +21,7 @@ import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.linuxtools.docker.core.AbstractRegistry;
 import org.eclipse.linuxtools.docker.core.DockerException;
+import org.eclipse.linuxtools.docker.core.DockerOperationCancelledException;
 import org.eclipse.linuxtools.docker.core.IDockerConnection;
 import org.eclipse.linuxtools.docker.core.IRegistryAccount;
 import org.eclipse.linuxtools.docker.ui.wizards.ImageSearch;
@@ -74,43 +75,37 @@ public class PullImageCommandHandler extends AbstractHandler {
 		return null;
 	}
 
-	private void performPullImage(final IDockerConnection connection,
-			final String imageName, final AbstractRegistry registry) {
-		final Job pullImageJob = new Job(DVMessages
-				.getFormattedString(PULL_IMAGE_JOB_TITLE, imageName)) {
+	private void performPullImage(final IDockerConnection connection, final String imageName,
+			final AbstractRegistry registry) {
+		final Job pullImageJob = new Job(DVMessages.getFormattedString(PULL_IMAGE_JOB_TITLE, imageName)) {
 
 			@Override
 			protected IStatus run(final IProgressMonitor monitor) {
-				monitor.beginTask(DVMessages.getString(PULL_IMAGE_JOB_TASK),
-						IProgressMonitor.UNKNOWN);
+				final DockerConnection dconn = (DockerConnection) connection;
+				monitor.beginTask(DVMessages.getString(PULL_IMAGE_JOB_TASK), IProgressMonitor.UNKNOWN);
 				// pull the image and let the progress
 				// handler refresh the images when done
 				try {
 					if (registry == null || registry.isDockerHubRegistry()) {
-						((DockerConnection) connection).pullImage(imageName,
-								new DefaultImagePullProgressHandler(connection,
-										imageName));
+						dconn.pullImage(imageName, new DefaultImagePullProgressHandler(connection, imageName, monitor));
 					} else {
-						String fullImageName = registry.getServerHost() + '/'
-								+ imageName;
+						String fullImageName = registry.getServerHost() + '/' + imageName;
 						if (registry instanceof IRegistryAccount) {
 							IRegistryAccount account = (IRegistryAccount) registry;
-							((DockerConnection) connection).pullImage(fullImageName,
-									account, new DefaultImagePullProgressHandler(
-											connection, fullImageName));
+							dconn.pullImage(fullImageName, account,
+									new DefaultImagePullProgressHandler(connection, fullImageName, monitor));
 						} else {
-							((DockerConnection) connection).pullImage(fullImageName,
-									new DefaultImagePullProgressHandler(connection,
-											fullImageName));
+							dconn.pullImage(fullImageName,
+									new DefaultImagePullProgressHandler(connection, fullImageName, monitor));
 						}
 					}
+				} catch (final DockerOperationCancelledException e) {
+					// Cancelled by user. Do nothing
 				} catch (final DockerException e) {
-					Display.getDefault().syncExec(() -> MessageDialog.openError(
-							PlatformUI.getWorkbench().getActiveWorkbenchWindow()
-									.getShell(),
-							DVMessages.getFormattedString(ERROR_PULLING_IMAGE,
-									imageName),
-							e.getMessage()));
+						Display.getDefault()
+								.syncExec(() -> MessageDialog.openError(
+										PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(),
+										DVMessages.getFormattedString(ERROR_PULLING_IMAGE, imageName), e.getMessage()));
 					// for now
 				} catch (InterruptedException | DockerCertificateException e) {
 					// do nothing

--- a/containers/org.eclipse.linuxtools.docker.ui/src/org/eclipse/linuxtools/internal/docker/ui/wizards/ImageRunSelectionPage.java
+++ b/containers/org.eclipse.linuxtools.docker.ui/src/org/eclipse/linuxtools/internal/docker/ui/wizards/ImageRunSelectionPage.java
@@ -71,6 +71,7 @@ import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.linuxtools.docker.core.AbstractRegistry;
 import org.eclipse.linuxtools.docker.core.DockerException;
+import org.eclipse.linuxtools.docker.core.DockerOperationCancelledException;
 import org.eclipse.linuxtools.docker.core.IDockerConnection;
 import org.eclipse.linuxtools.docker.core.IDockerContainer;
 import org.eclipse.linuxtools.docker.core.IDockerImage;
@@ -948,7 +949,9 @@ public class ImageRunSelectionPage extends WizardPage {
 				try {
 					connection.pullImage(imageName,
 							new DefaultImagePullProgressHandler(connection,
-									imageName));
+									imageName, monitor));
+				} catch (final DockerOperationCancelledException e) {
+					// Cancelled by user. Do nothing
 				} catch (final DockerException e) {
 					Display.getDefault().syncExec(() -> MessageDialog.openError(
 							PlatformUI.getWorkbench().getActiveWorkbenchWindow()


### PR DESCRIPTION
This fixes the cancellation of an image pull. I'm afraid I ended up in the API-Hell. Do I need to put `getDefaultPullImageProgressHandler()` into `IDockerConnection4`? It also seems like I have problem with my externalized string. Can I move that to internal?

@jjohnstn 