### PR TITLE
Modify Linux Tools gcov support to handle gcc 12

### DIFF
--- a/gcov/org.eclipse.linuxtools.gcov.core/src/org/eclipse/linuxtools/internal/gcov/parser/GcdaRecordsParser.java
+++ b/gcov/org.eclipse.linuxtools.gcov.core/src/org/eclipse/linuxtools/internal/gcov/parser/GcdaRecordsParser.java
@@ -35,6 +35,7 @@ public class GcdaRecordsParser {
     private static final int GCOV_TAG_PROGRAM_SUMMARY = 0xa3000000;
 
 	private static final int GCC_VER_900 = 1094266922; // GCC 9.0.0 ('A90*')
+	private static final int GCC_VER_1210 = 1110585632;// GCC 12.1.0 ('B21*')
 
 
     private final ArrayList<GcnoFunction> fnctns;
@@ -54,6 +55,7 @@ public class GcdaRecordsParser {
     public void parseGcdaRecord(DataInput stream) throws IOException, CoreException {
         // header data
         int magic = 0;
+		boolean readBytes = false;
 
         // data & flags to process tests
         GcnoFunction currentFnctn = null;
@@ -80,6 +82,10 @@ public class GcdaRecordsParser {
         // read stamp
         // stamp = stream.readInt();
         stream.readInt();
+		if (version >= GCC_VER_1210) {
+			stream.readInt(); // checksum
+			readBytes = true;
+		}
 
         while (true) {
             try {

--- a/gcov/org.eclipse.linuxtools.gcov.core/src/org/eclipse/linuxtools/internal/gcov/utils/GcovStringReader.java
+++ b/gcov/org.eclipse.linuxtools.gcov.core/src/org/eclipse/linuxtools/internal/gcov/utils/GcovStringReader.java
@@ -17,11 +17,11 @@ import java.io.IOException;
 
 public class GcovStringReader {
 
-    public static String readString(DataInput stream) throws IOException {
+	public static String readString(DataInput stream, boolean readBytes) throws IOException {
         String res = Messages.GcovStringReader_null_string;
         long length = stream.readInt() & MasksGenerator.UNSIGNED_INT_MASK;
         if (length != 0) {
-            int ln = ((int) length) << 2;
+			int ln = readBytes ? (int) length : ((int) length) << 2;
             byte[] name = new byte[ln];
             stream.readFully(name);
 			StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
- gcc 12 support has added a new chksum field in header
- gcc 12 support has changed length field to be in bytes instead
  of words
- fixes #71