### PR TITLE
Fix build with 4.25 stream

### DIFF
--- a/releng/org.eclipse.linuxtools.target/linuxtools-e4.25.target
+++ b/releng/org.eclipse.linuxtools.target/linuxtools-e4.25.target
@@ -16,14 +16,12 @@
 <unit id="com.github.jnr.jffi.native" version="1.2.23.v20211029-0121"/>
 <unit id="com.github.jnr.posix" version="3.0.54.v20200501-1917"/>
 <unit id="com.github.jnr.unixsocket" version="0.28.0.v20200501-1917"/>
-<unit id="com.google.gson" version="2.8.9.v20220111-1409"/>
 <unit id="com.google.guava" version="30.1.0.v20210127-2300"/>
 <unit id="org.mandas.docker-client" version="3.2.1.v20200519-1937"/>
 <unit id="org.mandas.docker-client.source" version="3.2.1.v20200519-1937"/>
 <unit id="javax.ws.rs" version="2.1.6.v20200505-2127"/>
 <unit id="jakarta.xml.bind" version="2.3.3.v20201118-1818"/>
 <unit id="com.github.jnr.x86asm" version="1.0.2.v20200501-1917"/>
-<unit id="org.apache.commons.codec" version="1.14.0.v20200818-1422"/>
 <unit id="org.apache.commons.compress" version="1.21.0.v20211103-2100"/>
 <unit id="org.apache.xerces" version="2.12.2.v20220131-0835"/>
 <unit id="org.glassfish.hk2.api" version="2.6.1.v20200513-1859"/>
@@ -39,7 +37,6 @@
 <unit id="org.glassfish.jersey.ext.entityfiltering" version="2.30.1.v20200513-1859"/>
 <unit id="org.glassfish.jersey.inject.jersey-hk2" version="2.30.1.v20200512-1802"/>
 <unit id="org.glassfish.jersey.media.jersey-media-json-jackson" version="2.30.1.v20200513-1859"/>
-<unit id="org.slf4j.api" version="1.7.30.v20200204-2150"/>
 <unit id="org.hamcrest" version="2.2.0.v20210711-0821"/>
 <unit id="org.bouncycastle.bcpkix" version="1.70.0.v20220105-1522"/>
 <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220531185310/repository/"/>
@@ -66,9 +63,12 @@
 <unit id="org.objectweb.asm.tree" version="0.0.0"/>
 <unit id="org.mockito.mockito-core" version="0.0.0"/>
 <unit id="assertj-core" version="0.0.0"/>
+<unit id="com.google.gson" version="0.0.0"/>
+<unit id="org.apache.commons.codec" version="0.0.0"/>
 <unit id="org.hamcrest.core" version="0.0.0"/>
 <unit id="org.apache.commons.io" version="0.0.0"/>
-<unit id="org.bouncycastle.bcprov" version="0.0.0"/>
+<unit id="org.slf4j.api" version="0.0.0"/>
+<unit id="bcprov" version="0.0.0"/>
 <repository location="https://download.eclipse.org/eclipse/updates/4.25-I-builds/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
By switching more libraries to be used from platform p2 repo and
adjusting symbolic names to match the maven central ones.