### PR TITLE
Fix NPE in HttpHijackWorkaround

### DIFF
--- a/containers/org.eclipse.linuxtools.docker.core/src/org/eclipse/linuxtools/internal/docker/core/HttpHijackWorkaround.java
+++ b/containers/org.eclipse.linuxtools.docker.core/src/org/eclipse/linuxtools/internal/docker/core/HttpHijackWorkaround.java
@@ -116,8 +116,8 @@ public class HttpHijackWorkaround {
 		Object res = getInternalField(stream, list, bundles);
 		if (res instanceof WritableByteChannel) {
 			return (WritableByteChannel) res;
-		} else if (res != null && res.getClass().getCanonicalName()
-				.equals("java.net.Socket.SocketInputStream")) { //$NON-NLS-1$
+		} else if (res != null && "java.net.Socket.SocketInputStream" //$NON-NLS-1$
+				.equals(res.getClass().getCanonicalName())) {
 			// if we are here, we are Java 13 or higher and have to use an
 			// alternate field reflection to get the socket
 			List<String[]> list2 = new LinkedList<>();


### PR DESCRIPTION
- reverse String.equals() call whereby the getCanonicalName() of a
  class may return null