### PR TITLE
Bug 580753 - gcov fails with c++ and gcc-12.2.1

### DIFF
--- a/gcov/org.eclipse.linuxtools.gcov.core/META-INF/MANIFEST.MF
+++ b/gcov/org.eclipse.linuxtools.gcov.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.linuxtools.gcov.core;singleton:=true
-Bundle-Version: 6.2.0.qualifier
+Bundle-Version: 6.3.0.qualifier
 Bundle-Vendor: %bundleProvider
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/gcov/org.eclipse.linuxtools.gcov.core/pom.xml
+++ b/gcov/org.eclipse.linuxtools.gcov.core/pom.xml
@@ -19,7 +19,7 @@
   </parent>
 
   <artifactId>org.eclipse.linuxtools.gcov.core</artifactId>
-  <version>6.2.0-SNAPSHOT</version>
+  <version>6.3.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <name>Linux Tools GCov Plug-in</name>

--- a/gcov/org.eclipse.linuxtools.gcov.core/src/org/eclipse/linuxtools/internal/gcov/parser/GcdaRecordsParser.java
+++ b/gcov/org.eclipse.linuxtools.gcov.core/src/org/eclipse/linuxtools/internal/gcov/parser/GcdaRecordsParser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2021 STMicroelectronics and others.
+ * Copyright (c) 2009, 2022 STMicroelectronics and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -55,6 +55,7 @@ public class GcdaRecordsParser {
     public void parseGcdaRecord(DataInput stream) throws IOException, CoreException {
         // header data
         int magic = 0;
+		@SuppressWarnings("unused")
 		boolean readBytes = false;
 
         // data & flags to process tests
@@ -104,6 +105,9 @@ public class GcdaRecordsParser {
                 // parse gcda data
                 switch (tag) {
                 case GCOV_TAG_FUNCTION: {
+					if (length == 0) {
+						continue;
+					}
                     long fnctnId = stream.readInt() & MasksGenerator.UNSIGNED_INT_MASK;
                     if (!fnctns.isEmpty()) {
                         boolean fnctnFound = false;
@@ -147,10 +151,12 @@ public class GcdaRecordsParser {
 
                 case GCOV_COUNTER_ARCS: {
                     if (currentFnctn == null) {
-                        String message = Messages.GcdaRecordsParser_func_counter_error;
-						IStatus status = Status.error(message);
-                        throw new CoreException(status);
+						continue;
                     }
+
+					if (version >= GCC_VER_1210 && length > Integer.MAX_VALUE) {
+						continue;
+					}
 
                     ArrayList<Block> fnctnBlcks = currentFnctn.getFunctionBlocks();
                     if (fnctnBlcks.isEmpty()) {


### PR DESCRIPTION
- modify GcdaRecordsParser.parseGcdaRecord() to handle the gcc12 case where the length of a GCOV_COUNTER_ARCS is actually negative in which case ignore and continue
- fix the logic for an unknown fn for GCOV_COUNTER_ARCS and again ignore and continue
- ignore function tags with zero length