### PR TITLE
Fix deadlock in Linux Tools tests

### DIFF
--- a/profiling/org.eclipse.linuxtools.profiling.tests/src/org/eclipse/linuxtools/profiling/tests/AbstractTest.java
+++ b/profiling/org.eclipse.linuxtools.profiling.tests/src/org/eclipse/linuxtools/profiling/tests/AbstractTest.java
@@ -286,6 +286,8 @@ public abstract class AbstractTest {
 
         // Index the project
         IIndexManager indexManager = CCorePlugin.getIndexManager();
+        indexManager.joinIndexer(IIndexManager.FOREVER,
+                new NullProgressMonitor());
         indexManager.reindex(proj);
         indexManager.joinIndexer(IIndexManager.FOREVER,
                 new NullProgressMonitor());


### PR DESCRIPTION
- creation of project is starting an index but we ask for a reindex immediately
- this causes a deadlock to occur
- add a joinIndexer call in AbstractTest preceding the reindex request