### PR TITLE
Fix build after bouncycastle and slf4j updates in platform

### DIFF
--- a/releng/org.eclipse.linuxtools.docker-site/category.xml
+++ b/releng/org.eclipse.linuxtools.docker-site/category.xml
@@ -160,7 +160,7 @@
    <iu id="com.github.jnr.x86asm" version="0.0.0">
         <category name="Docker Client Dependencies"/>
    </iu>
-   <iu id="org.bouncycastle.bcprov" version="0.0.0">
+   <iu id="bcprov" version="0.0.0">
         <category name="Docker Client Dependencies"/>
    </iu>
    <iu id="org.bouncycastle.bcpkix" version="0.0.0">

--- a/releng/org.eclipse.linuxtools.target/linuxtools-e4.26.target
+++ b/releng/org.eclipse.linuxtools.target/linuxtools-e4.26.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="linuxtools-e4.26" sequenceNumber="1">
+<target name="linuxtools-e4.26" sequenceNumber="2">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="com.fasterxml.jackson.core.jackson-annotations" version="2.13.2.v20220426-1653"/>
@@ -66,8 +66,8 @@
 <unit id="org.apache.commons.codec" version="0.0.0"/>
 <unit id="org.apache.commons.commons-io" version="0.0.0"/>
 <unit id="org.hamcrest.core" version="0.0.0"/>
-<unit id="org.slf4j.api" version="0.0.0"/>
-<unit id="org.bouncycastle.bcprov" version="0.0.0"/>
+<unit id="slf4j.api" version="0.0.0"/>
+<unit id="bcprov" version="0.0.0"/>
 <repository location="https://download.eclipse.org/eclipse/updates/4.26-I-builds/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
Moving to upstream symbolic names forces us to do so too.