### PR TITLE
Switch to use new jnr stack

### DIFF
--- a/releng/org.eclipse.linuxtools.docker-site/category.xml
+++ b/releng/org.eclipse.linuxtools.docker-site/category.xml
@@ -133,10 +133,7 @@
    <iu id="javax.annotation" version="0.0.0">
         <category name="Docker Client Dependencies"/>
    </iu>
-   <iu id="com.github.jnr.jffi" version="0.0.0">
-        <category name="Docker Client Dependencies"/>
-   </iu>
-   <iu id="com.github.jnr.jffi.native" version="0.0.0">
+   <iu id="com.github.jnr.a64asm" version="0.0.0">
         <category name="Docker Client Dependencies"/>
    </iu>
    <iu id="com.github.jnr.constants" version="0.0.0">
@@ -146,6 +143,12 @@
         <category name="Docker Client Dependencies"/>
    </iu>
    <iu id="com.github.jnr.ffi" version="0.0.0">
+        <category name="Docker Client Dependencies"/>
+   </iu>
+   <iu id="com.github.jnr.jffi" version="0.0.0">
+        <category name="Docker Client Dependencies"/>
+   </iu>
+   <iu id="com.github.jnr.jffi.native" version="0.0.0">
         <category name="Docker Client Dependencies"/>
    </iu>
    <iu id="com.github.jnr.posix" version="0.0.0">

--- a/releng/org.eclipse.linuxtools.target/linuxtools-e4.27.target
+++ b/releng/org.eclipse.linuxtools.target/linuxtools-e4.27.target
@@ -9,19 +9,20 @@
 <unit id="com.fasterxml.jackson.datatype.jackson-datatype-guava" version="2.13.2.v20220426-1653"/>
 <unit id="com.fasterxml.jackson.jaxrs.jackson-jaxrs-base" version="2.13.2.v20220426-1653"/>
 <unit id="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider" version="2.13.2.v20220426-1653"/>
-<unit id="com.github.jnr.constants" version="0.9.15.v20221112-0806"/>
-<unit id="com.github.jnr.enxio" version="0.25.0.v20221112-0806"/>
-<unit id="com.github.jnr.ffi" version="2.1.12.v20221112-0806"/>
-<unit id="com.github.jnr.jffi" version="1.2.23.v20211029-0121"/>
-<unit id="com.github.jnr.jffi.native" version="1.2.23.v20211029-0121"/>
-<unit id="com.github.jnr.posix" version="3.0.54.v20221112-0806"/>
-<unit id="com.github.jnr.unixsocket" version="0.28.0.v20221112-0806"/>
+<unit id="com.github.jnr.a64asm" version="1.0.0.v20221215-1656"/>
+<unit id="com.github.jnr.constants" version="0.10.3.v20221215-1656"/>
+<unit id="com.github.jnr.enxio" version="0.32.13.v20221215-1656"/>
+<unit id="com.github.jnr.ffi" version="2.2.11.v20221215-1656"/>
+<unit id="com.github.jnr.jffi" version="1.3.9.v20221215-1656"/>
+<unit id="com.github.jnr.jffi.native" version="1.3.9.v20221215-1656"/>
+<unit id="com.github.jnr.posix" version="3.1.15.v20221215-1656"/>
+<unit id="com.github.jnr.unixsocket" version="0.38.17.v20221215-1656"/>
+<unit id="com.github.jnr.x86asm" version="1.0.2.v20221112-0806"/>
 <unit id="com.google.guava" version="30.1.0.v20221112-0806"/>
 <unit id="org.mandas.docker-client" version="3.2.1.v20221112-0806"/>
 <unit id="org.mandas.docker-client.source" version="3.2.1.v20221112-0806"/>
 <unit id="javax.ws.rs" version="2.1.6.v20221203-1659"/>
 <unit id="jakarta.xml.bind" version="2.3.3.v20221203-1659"/>
-<unit id="com.github.jnr.x86asm" version="1.0.2.v20221112-0806"/>
 <unit id="org.apache.commons.compress" version="1.22.0.v20221207-1049"/>
 <unit id="org.apache.xerces" version="2.12.2.v20220131-0835"/>
 <unit id="org.glassfish.hk2.api" version="2.6.1.v20221203-1659"/>
@@ -40,7 +41,7 @@
 <unit id="org.hamcrest" version="2.2.0.v20210711-0821"/>
 <unit id="org.bouncycastle.bcpkix" version="1.72.0.v20221013-1810"/>
 <unit id="org.aopalliance" version="1.0.0.v20220404-1927"/>
-<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/I20221207195208/repository"/>
+<repository location="https://download.eclipse.org/tools/orbit/downloads/2023-03"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.cyberneko.html" version="1.9.14.v201105210654"/>


### PR DESCRIPTION
- change linuxtools-e4.27 target to use new Orbit repo
- add new jnr stack including a64asm support
- add new a64asm to docker category.xml