### PR TITLE
Build against 2023-06/4.28 stream

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <mirror-docker-repo-name>updates-docker-nightly</mirror-docker-repo-name>
     <mirror-mylyn-repo-name>updates-mylyn-nightly</mirror-mylyn-repo-name>
     <tycho-version>4.0.0-SNAPSHOT</tycho-version>
-    <target-platform>linuxtools-e4.27</target-platform>
+    <target-platform>linuxtools-e4.28</target-platform>
     <sonar.core.codeCoveragePlugin>jacoco</sonar.core.codeCoveragePlugin>
     <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
     <sonar.jacoco.reportPath>${project.basedir}/../../target/jacoco.exec</sonar.jacoco.reportPath>

--- a/releng/org.eclipse.linuxtools.target/linuxtools-e4.28.target
+++ b/releng/org.eclipse.linuxtools.target/linuxtools-e4.28.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="linuxtools-e4.27" sequenceNumber="1">
+<target name="linuxtools-e4.28" sequenceNumber="1">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="com.fasterxml.jackson.core.jackson-annotations" version="2.13.2.v20220426-1653"/>
@@ -67,7 +67,7 @@
 <unit id="org.hamcrest.core" version="0.0.0"/>
 <unit id="slf4j.api" version="0.0.0"/>
 <unit id="bcprov" version="0.0.0"/>
-<repository location="https://download.eclipse.org/eclipse/updates/4.27-I-builds/"/>
+<repository location="https://download.eclipse.org/eclipse/updates/4.28-I-builds/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.license.feature.group" version="0.0.0"/>
@@ -94,7 +94,7 @@
 <unit id="org.eclipse.zest.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.lsp4e" version="0.0.0"/>
 <unit id="org.eclipse.tm4e.feature.feature.group" version="0.0.0"/>
-<repository location="https://download.eclipse.org/releases/2022-12/"/>
+<repository location="https://download.eclipse.org/releases/2023-03/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.reddeer.eclipse.feature.feature.group" version="0.0.0"/>


### PR DESCRIPTION
Switch the target platform accordingly.
Fixes https://github.com/eclipse-linuxtools/org.eclipse.linuxtools/issues/167