### PR TITLE
Switch Docker Tooling to use config instead of containerConfig

### DIFF
--- a/containers/org.eclipse.linuxtools.docker.ui/src/org/eclipse/linuxtools/docker/ui/launch/ContainerLauncher.java
+++ b/containers/org.eclipse.linuxtools.docker.ui/src/org/eclipse/linuxtools/docker/ui/launch/ContainerLauncher.java
@@ -1131,8 +1131,8 @@ public class ContainerLauncher {
 				.workingDir(workingDir);
 
 		// preserve any entry point specified in the image
-		if (info.containerConfig() != null) {
-			List<String> entrypoint = info.containerConfig().entrypoint();
+		if (info.config() != null) {
+			List<String> entrypoint = info.config().entrypoint();
 			if (entrypoint != null && !entrypoint.isEmpty()) {
 				builder = builder.entryPoint(entrypoint);
 			}

--- a/containers/org.eclipse.linuxtools.docker.ui/src/org/eclipse/linuxtools/internal/docker/ui/launch/LaunchConfigurationUtils.java
+++ b/containers/org.eclipse.linuxtools.docker.ui/src/org/eclipse/linuxtools/internal/docker/ui/launch/LaunchConfigurationUtils.java
@@ -171,7 +171,7 @@ public class LaunchConfigurationUtils {
 						.getImageInfo(image.id());
 				if (imageInfo != null) {
 					workingCopy.setAttribute(PUBLISHED_PORTS,
-							serializePortBindings(imageInfo.containerConfig()
+							serializePortBindings(imageInfo.config()
 									.exposedPorts()));
 				}
 			} else {


### PR DESCRIPTION
- newer Docker releases no longer fill in the containerConfig data in the DockerImageInfo so use the config data which is the same structure
- fixes #335