### PR TITLE
Fix the problem of Gcov tool inaccurately parsing gcc data file.

### DIFF
--- a/gcov/org.eclipse.linuxtools.gcov.core/src/org/eclipse/linuxtools/internal/gcov/parser/Block.java
+++ b/gcov/org.eclipse.linuxtools.gcov.core/src/org/eclipse/linuxtools/internal/gcov/parser/Block.java
@@ -19,7 +19,7 @@ public class Block implements Serializable{
 
     private static final long serialVersionUID = -7665287885679756014L;
     private final ArrayList<Arc> entryArcs = new ArrayList<>();
-    private final ArrayList<Arc> exitArcs = new ArrayList<>();
+    private ArrayList<Arc> exitArcs = new ArrayList<>();
     private final long flag;
     private long numSuccs = 0;
     private long  numPreds = 0;
@@ -51,6 +51,10 @@ public class Block implements Serializable{
 
     public ArrayList<Arc> getExitArcs() {
         return exitArcs;
+    }
+
+    public void setExitArcs(ArrayList<Arc> exitArcs) {
+        this.exitArcs = exitArcs;
     }
 
     public boolean isCallSite() {

--- a/gcov/org.eclipse.linuxtools.gcov.core/src/org/eclipse/linuxtools/internal/gcov/parser/GcnoFunction.java
+++ b/gcov/org.eclipse.linuxtools.gcov.core/src/org/eclipse/linuxtools/internal/gcov/parser/GcnoFunction.java
@@ -29,7 +29,14 @@ public class GcnoFunction implements Serializable, Comparable<GcnoFunction> {
     private ArrayList<Block> functionBlocks = new ArrayList<>();
     private int numCounts = 0, numBlocks = 0;
     private final CoverageInfo cvrge = new CoverageInfo();
-	private boolean hasCatch = false;
+    private boolean hasCatch = false;
+
+    /*
+     * Array of basic blocks.  Like in GCC, the entry block is
+     * at functionBlocks[0] and the exit block is at functionBlocks[1].
+     */
+    private static final int entryBlockIndice = 0;
+    private static final int exitBlockIndice = 1;
 
     public GcnoFunction(long fnctnIdent, long fnctnChksm, String fnctnName, String fnctnSrcFle, long fnctnFrstLnNmbr) {
         this.ident = fnctnIdent;
@@ -106,11 +113,11 @@ public class GcnoFunction implements Serializable, Comparable<GcnoFunction> {
 
         // Function should contain at least one block
         if (fnctnBlcks.size() >= 2) {
-            if (fnctnBlcks.get(0).getNumPreds() == 0) {
-                fnctnBlcks.get(0).setNumPreds(50000);
+            if (fnctnBlcks.get(entryBlockIndice).getNumPreds() == 0) {
+                fnctnBlcks.get(entryBlockIndice).setNumPreds(50000);
             }
-            if (fnctnBlcks.get(fnctnBlcks.size() - 1).getNumSuccs() == 0) {
-                fnctnBlcks.get(fnctnBlcks.size() - 1).setNumSuccs(50000);
+            if (fnctnBlcks.get(exitBlockIndice).getNumSuccs() == 0) {
+                fnctnBlcks.get(exitBlockIndice).setNumSuccs(50000);
             }
         }
 
@@ -210,7 +217,7 @@ public class GcnoFunction implements Serializable, Comparable<GcnoFunction> {
                     blcksrc.decNumSuccs();
 
                     if (blcksrc.isCountValid()) {
-                        if (blcksrc.getNumSuccs() == 1 && !blcksrc.isInvalidChain()) {
+                        if (blcksrc.getNumSuccs() == 1 && !blcksrc.isValidChain()) {
                             blcksrc.setValidChain(true);
                             validBlocks.add(blcksrc);
                         }


### PR DESCRIPTION
Fix the problem of Gcov tool inaccurately parsing data file generated by gcc 10.1 and later versions. This problem could cause Gcov tool to not count the return statement at the end of each function.

The basis for fixing this problem is that in the gcov.cc source code of gcc 10.1 and subsequent versions, the index value of entryblock is specified as 0 and that of exitblock is specified as 1. However, in the source code of this project Gcnofuntion.java, the index value of exitblock is set to fnctnBlcks.size()-1 at lines 119 and 120.

Other minor fixes include reducing unnecessary loops in GcnoRecordParser.java and adding sorting operations for arc successor nodes which originally performed in gcc source code and disappear in our tool.