### PR TITLE
Add jackson-module-jaxb-annotations to docker site

### DIFF
--- a/releng/org.eclipse.linuxtools.docker-site/category.xml
+++ b/releng/org.eclipse.linuxtools.docker-site/category.xml
@@ -120,6 +120,9 @@
    <iu id="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider" version="0.0.0">
         <category name="Docker Client Dependencies"/>
    </iu>
+   <iu id="com.fasterxml.jackson.module.jackson-module-jaxb-annotations" version="0.0.0">
+        <category name="Docker Client Dependencies"/>
+   </iu>
    <iu id="jakarta.ws.rs-api" version="0.0.0">
         <category name="Docker Client Dependencies"/>
    </iu>


### PR DESCRIPTION
Fixes broken installation due to missing dependency