### PR TITLE
Explicitly import org.glassfish.jersey.apache.connector package

### DIFF
--- a/containers/org.eclipse.linuxtools.docker.core/META-INF/MANIFEST.MF
+++ b/containers/org.eclipse.linuxtools.docker.core/META-INF/MANIFEST.MF
@@ -31,5 +31,6 @@ Import-Package: com.fasterxml.jackson.annotation;version="2.10.3",
  javax.ws.rs;version="2.0.1",
  javax.ws.rs.core;version="2.0.1",
  javax.xml.bind;version="2.3.3",
- javax.ws.rs.client;version="2.0.1"
+ javax.ws.rs.client;version="2.0.1",
+ org.glassfish.jersey.apache.connector
 Automatic-Module-Name: org.eclipse.linuxtools.docker.core


### PR DESCRIPTION
To ensure it is installed at runtime as only test packages were requiring it. Making install from update site non usable.