### PR TITLE
Use jffi native from Orbit

### DIFF
--- a/containers/org.eclipse.linuxtools.docker.ui/META-INF/MANIFEST.MF
+++ b/containers/org.eclipse.linuxtools.docker.ui/META-INF/MANIFEST.MF
@@ -28,7 +28,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.e4.ui.model.workbench;bundle-version="1.2.0",
  org.eclipse.tm.terminal.view.ui;bundle-version="4.1.0",
  org.eclipse.tm.terminal.view.core;bundle-version="4.0.0",
- org.apache.commons.compress;bundle-version="1.6.0"
+ org.apache.commons.commons-compress;bundle-version="1.23.0"
 Import-Package: javax.xml.bind;version="2.3.3",
  javax.annotation;version="1.3.5"
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/releng/org.eclipse.linuxtools.docker-site/category.xml
+++ b/releng/org.eclipse.linuxtools.docker-site/category.xml
@@ -148,7 +148,7 @@
    <iu id="org.aopalliance" version="0.0.0">
         <category name="Docker Client Dependencies"/>
    </iu>
-   <iu id="org.apache.commons.compress" version="0.0.0">
+   <iu id="org.apache.commons.commons-compress" version="0.0.0">
         <category name="Docker Client Dependencies"/>
    </iu>
    <category-def name="Linux Tools" label="Linux Tools">

--- a/releng/org.eclipse.linuxtools.target/linuxtools-e4.29.target
+++ b/releng/org.eclipse.linuxtools.target/linuxtools-e4.29.target
@@ -5,9 +5,10 @@
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="com.github.jnr.a64asm" version="1.0.0.v20230715-0746"/>
 <unit id="com.github.jnr.x86asm" version="1.0.2.v20230715-0746"/>
+<unit id="com.github.jnr.jffi.native" version="1.3.11.v20230807-0900"/>
 <unit id="org.aopalliance" version="1.0.0.v20230720-0728"/>
-<unit id="org.apache.httpcomponents.httpcore" version="4.4.16.v20221207-1049"/>
-<unit id="org.apache.httpcomponents.httpclient" version="4.5.14.v20230516-1249"/>
+<unit id="org.apache.httpcomponents.httpcore" version="4.4.16"/>
+<unit id="org.apache.httpcomponents.httpclient" version="4.5.14"/>
 <unit id="org.codelibs.nekohtml" version="2.1.2.v20230802-0829"/>
 <unit id="org.codelibs.nekohtml.source" version="2.1.2.v20230802-0829"/>
 <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly/latest"/>
@@ -122,13 +123,6 @@
 			</dependency>
 			<dependency>
 				<groupId>com.github.jnr</groupId>
-				<artifactId>jffi</artifactId>
-				<version>1.3.11</version>
-				<type>jar</type>
-				<classifier>native</classifier>
-			</dependency>
-			<dependency>
-				<groupId>com.github.jnr</groupId>
 				<artifactId>jnr-constants</artifactId>
 				<version>0.10.4</version>
 				<type>jar</type>
@@ -155,6 +149,12 @@
 				<groupId>com.github.jnr</groupId>
 				<artifactId>jnr-unixsocket</artifactId>
 				<version>0.38.20</version>
+				<type>jar</type>
+			</dependency>
+			<dependency>
+				<groupId>com.google.guava</groupId>
+				<artifactId>failureaccess</artifactId>
+				<version>1.0.1</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Orbit signs the native libs to get MacOS notarization succeed. See https://github.com/eclipse-orbit/orbit-simrel/issues/7 for details.