### PR TITLE
Remove commons-codec from target platform

### DIFF
--- a/releng/org.eclipse.linuxtools.target/linuxtools-e4.30.target
+++ b/releng/org.eclipse.linuxtools.target/linuxtools-e4.30.target
@@ -29,7 +29,6 @@
 <unit id="org.mockito.mockito-core" version="0.0.0"/>
 <unit id="assertj-core" version="0.0.0"/>
 <unit id="com.google.gson" version="0.0.0"/>
-<unit id="org.apache.commons.codec" version="0.0.0"/>
 <unit id="org.apache.commons.commons-io" version="0.0.0"/>
 <unit id="org.hamcrest" version="0.0.0"/>
 <unit id="slf4j.api" version="0.0.0"/>


### PR DESCRIPTION
It's no longer in Platform p2 repo and seems to not be used here too.