### PR TITLE
Format and modernization of o.e.linuxtools.valgrind.ui.tests

### DIFF
--- a/valgrind/org.eclipse.linuxtools.valgrind.ui.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/valgrind/org.eclipse.linuxtools.valgrind.ui.tests/.settings/org.eclipse.jdt.core.prefs
@@ -96,3 +96,4 @@ org.eclipse.jdt.core.compiler.problem.unusedWarningToken=warning
 org.eclipse.jdt.core.compiler.problem.varargsArgumentNeedCast=warning
 org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.source=17
+org.eclipse.jdt.core.javaFormatter=org.eclipse.jdt.core.defaultJavaFormatter

--- a/valgrind/org.eclipse.linuxtools.valgrind.ui.tests/.settings/org.eclipse.jdt.ui.prefs
+++ b/valgrind/org.eclipse.linuxtools.valgrind.ui.tests/.settings/org.eclipse.jdt.ui.prefs
@@ -1,5 +1,6 @@
 eclipse.preferences.version=1
 editor_save_participant_org.eclipse.jdt.ui.postsavelistener.cleanup=true
+formatter_settings_version=23
 sp_cleanup.add_default_serial_version_id=true
 sp_cleanup.add_generated_serial_version_id=false
 sp_cleanup.add_missing_annotations=true

--- a/valgrind/org.eclipse.linuxtools.valgrind.ui.tests/src/org/eclipse/linuxtools/internal/valgrind/ui/quickfixes/tests/WrongDeallocationResolutionTest.java
+++ b/valgrind/org.eclipse.linuxtools.valgrind.ui.tests/src/org/eclipse/linuxtools/internal/valgrind/ui/quickfixes/tests/WrongDeallocationResolutionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2018 IBM Corporation and others.
+ * Copyright (c) 2013, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.InputStream;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.Scanner;
 
 import org.eclipse.core.resources.IMarker;
@@ -36,145 +35,141 @@ import org.junit.Test;
 
 public class WrongDeallocationResolutionTest extends AbstractValgrindTest {
 
-    private final String EMPTY_STRING = ""; //$NON-NLS-1$
-    private final String VALGRIND_MARKER_TYPE = "org.eclipse.linuxtools.valgrind.launch.marker"; //$NON-NLS-1$
-    private Document document;
-    private IMarker[] markers;
+	private final String EMPTY_STRING = ""; //$NON-NLS-1$
+	private final String VALGRIND_MARKER_TYPE = "org.eclipse.linuxtools.valgrind.launch.marker"; //$NON-NLS-1$
+	private Document document;
+	private IMarker[] markers;
 
-    @Override
-    protected String getToolID() {
-        return "org.eclipse.linuxtools.valgrind.launch.memcheck"; //$NON-NLS-1$
-    }
+	@Override
+	protected String getToolID() {
+		return "org.eclipse.linuxtools.valgrind.launch.memcheck"; //$NON-NLS-1$
+	}
 
-    @Before
-    public void prep() throws Exception {
-        proj = createProjectAndBuild("wrongDeallocTest"); //$NON-NLS-1$
-        ILaunchConfiguration config = createConfiguration(proj.getProject());
-        doLaunch(config, "wrongDeallocTest"); //$NON-NLS-1$
+	@Before
+	public void prep() throws Exception {
+		proj = createProjectAndBuild("wrongDeallocTest"); //$NON-NLS-1$
+		ILaunchConfiguration config = createConfiguration(proj.getProject());
+		doLaunch(config, "wrongDeallocTest"); //$NON-NLS-1$
 
-        document = new Document();
-        InputStream fileInputStream = proj.getProject()
-                .getFile("wrongDealloc.cpp").getContents(); //$NON-NLS-1$
-        try (Scanner scanner = new Scanner(fileInputStream)) {
-            scanner.useDelimiter("\\A"); //$NON-NLS-1$
-            String content;
-            if (scanner.hasNext()) {
-                content = scanner.next();
-            } else {
-                content = EMPTY_STRING;
-            }
-            document.set(content);
-        }
-        markers = proj.getProject().findMarkers(VALGRIND_MARKER_TYPE, true, 1);
-        Arrays.sort(markers, new MarkerComparator());
-    }
+		document = new Document();
+		InputStream fileInputStream = proj.getProject().getFile("wrongDealloc.cpp").getContents(); //$NON-NLS-1$
+		try (Scanner scanner = new Scanner(fileInputStream)) {
+			scanner.useDelimiter("\\A"); //$NON-NLS-1$
+			String content;
+			if (scanner.hasNext()) {
+				content = scanner.next();
+			} else {
+				content = EMPTY_STRING;
+			}
+			document.set(content);
+		}
+		markers = proj.getProject().findMarkers(VALGRIND_MARKER_TYPE, true, 1);
+		Arrays.sort(markers, (marker1, marker2) -> {
+			int line1 = marker1.getAttribute(IMarker.LINE_NUMBER, -1);
+			int line2 = marker2.getAttribute(IMarker.LINE_NUMBER, -1);
 
-    @Override
-    @After
-    public void tearDown() throws CoreException {
-        deleteProject(proj);
-        super.tearDown();
-    }
+			if (line1 > line2) {
+				return 1;
+			} else if (line2 > line1) {
+				return -1;
+			}
 
-    @Test
-    public void testMallocDeleteQuickFix() throws CoreException {
-        IMarker mallocDeleteMarker = markers[1];
-        int markerLine = mallocDeleteMarker.getAttribute(IMarker.LINE_NUMBER,
-                -1);
+			String message1 = "";
+			String message2 = "";
+			try {
+				message1 = (String) marker1.getAttribute(IMarker.MESSAGE);
+				message2 = (String) marker2.getAttribute(IMarker.MESSAGE);
+			} catch (CoreException e) {
+			}
+			return message1.compareTo(message2);
+		});
+	}
 
-        createResolutionAndApply(mallocDeleteMarker);
+	@Override
+	@After
+	public void tearDown() throws CoreException {
+		deleteProject(proj);
+		super.tearDown();
+	}
 
-        String newContent = getLineContent(document, markerLine);
-        assertTrue(newContent.contains("free")); //$NON-NLS-1$
-        assertFalse(newContent.contains("delete")); //$NON-NLS-1$
-    }
+	@Test
+	public void testMallocDeleteQuickFix() throws CoreException {
+		IMarker mallocDeleteMarker = markers[1];
+		int markerLine = mallocDeleteMarker.getAttribute(IMarker.LINE_NUMBER, -1);
 
-    @Test
-    public void testMallocDeleteArrayQuickFix() throws CoreException {
-        IMarker mallocDeleteArrayMarker = markers[3];
-        int markerLine = mallocDeleteArrayMarker.getAttribute(
-                IMarker.LINE_NUMBER, -1);
+		createResolutionAndApply(mallocDeleteMarker);
 
-        createResolutionAndApply(mallocDeleteArrayMarker);
+		String newContent = getLineContent(document, markerLine);
+		assertTrue(newContent.contains("free")); //$NON-NLS-1$
+		assertFalse(newContent.contains("delete")); //$NON-NLS-1$
+	}
 
-        String newContent = getLineContent(document, markerLine);
-        assertTrue(newContent.contains("free")); //$NON-NLS-1$
-        assertFalse(newContent.contains("delete")); //$NON-NLS-1$
-        assertFalse(newContent.contains("[")); //$NON-NLS-1$
-    }
+	@Test
+	public void testMallocDeleteArrayQuickFix() throws CoreException {
+		IMarker mallocDeleteArrayMarker = markers[3];
+		int markerLine = mallocDeleteArrayMarker.getAttribute(IMarker.LINE_NUMBER, -1);
 
-    @Test
-    public void testNewFreeQuickFix() throws CoreException {
-        IMarker newFreeMarker = markers[5];
-        int markerLine = newFreeMarker.getAttribute(IMarker.LINE_NUMBER, -1);
+		createResolutionAndApply(mallocDeleteArrayMarker);
 
-        createResolutionAndApply(newFreeMarker);
+		String newContent = getLineContent(document, markerLine);
+		assertTrue(newContent.contains("free")); //$NON-NLS-1$
+		assertFalse(newContent.contains("delete")); //$NON-NLS-1$
+		assertFalse(newContent.contains("[")); //$NON-NLS-1$
+	}
 
-        String newContent = getLineContent(document, markerLine);
-        assertTrue(newContent.contains("delete")); //$NON-NLS-1$
-        assertFalse(newContent.contains("free")); //$NON-NLS-1$
-    }
+	@Test
+	public void testNewFreeQuickFix() throws CoreException {
+		IMarker newFreeMarker = markers[5];
+		int markerLine = newFreeMarker.getAttribute(IMarker.LINE_NUMBER, -1);
 
-    @Test
-    public void testNewArrayFreeQuickFix() throws CoreException {
-        IMarker newArrayFreeMarker = markers[7];
-        int markerLine = newArrayFreeMarker.getAttribute(IMarker.LINE_NUMBER,
-                -1);
+		createResolutionAndApply(newFreeMarker);
 
-        createResolutionAndApply(newArrayFreeMarker);
+		String newContent = getLineContent(document, markerLine);
+		assertTrue(newContent.contains("delete")); //$NON-NLS-1$
+		assertFalse(newContent.contains("free")); //$NON-NLS-1$
+	}
 
-        String newContent = getLineContent(document, markerLine);
-        assertTrue(newContent.contains("delete[]")); //$NON-NLS-1$
-        assertFalse(newContent.contains("free")); //$NON-NLS-1$
-    }
+	@Test
+	public void testNewArrayFreeQuickFix() throws CoreException {
+		IMarker newArrayFreeMarker = markers[7];
+		int markerLine = newArrayFreeMarker.getAttribute(IMarker.LINE_NUMBER, -1);
 
-    @Test
-    public void testNewArrayDeleteQuickFix() throws CoreException {
-        IMarker newArrayDeleteMarker = markers[9];
-        int markerLine = newArrayDeleteMarker.getAttribute(IMarker.LINE_NUMBER,
-                -1);
+		createResolutionAndApply(newArrayFreeMarker);
 
-        createResolutionAndApply(newArrayDeleteMarker);
+		String newContent = getLineContent(document, markerLine);
+		assertTrue(newContent.contains("delete[]")); //$NON-NLS-1$
+		assertFalse(newContent.contains("free")); //$NON-NLS-1$
+	}
 
-        String newContent = getLineContent(document, markerLine);
-        assertTrue(newContent.contains("delete[]")); //$NON-NLS-1$
-    }
+	@Test
+	public void testNewArrayDeleteQuickFix() throws CoreException {
+		IMarker newArrayDeleteMarker = markers[9];
+		int markerLine = newArrayDeleteMarker.getAttribute(IMarker.LINE_NUMBER, -1);
 
-    private void createResolutionAndApply(IMarker marker) throws CoreException {
-        WrongDeallocationResolution resolution = new WrongDeallocationResolution();
-        assertNotNull(resolution);
+		createResolutionAndApply(newArrayDeleteMarker);
 
-        int numMarkersBefore = proj.getProject().findMarkers(
-                VALGRIND_MARKER_TYPE, true, 1).length;
-        resolution.apply(marker, document);
-        int numMarkersAfter = proj.getProject().findMarkers(
-                VALGRIND_MARKER_TYPE, true, 1).length;
+		String newContent = getLineContent(document, markerLine);
+		assertTrue(newContent.contains("delete[]")); //$NON-NLS-1$
+	}
 
-        assertEquals(numMarkersAfter, numMarkersBefore - 2);
-    }
+	private void createResolutionAndApply(IMarker marker) throws CoreException {
+		WrongDeallocationResolution resolution = new WrongDeallocationResolution();
+		assertNotNull(resolution);
 
-    private String getLineContent(Document document, int line) {
-        try {
-            int lineOffset = document.getLineOffset(line - 1);
-            int lineLength = document.getLineLength(line - 1);
-            return document.get(lineOffset, lineLength);
-        } catch (BadLocationException e) {
-            return null;
-        }
-    }
+		int numMarkersBefore = proj.getProject().findMarkers(VALGRIND_MARKER_TYPE, true, 1).length;
+		resolution.apply(marker, document);
+		int numMarkersAfter = proj.getProject().findMarkers(VALGRIND_MARKER_TYPE, true, 1).length;
 
-    private static class MarkerComparator implements Comparator<IMarker> {
-        @Override
-        public int compare(IMarker marker1, IMarker marker2) {
-            int line1 = marker1.getAttribute(IMarker.LINE_NUMBER, -1);
-            int line2 = marker2.getAttribute(IMarker.LINE_NUMBER, -1);
+		assertEquals(numMarkersAfter, numMarkersBefore - 2);
+	}
 
-            if (line1 > line2) {
-                return 1;
-            } else if (line2 > line1) {
-                return -1;
-            }
-            return 0;
-        }
-    }
+	private String getLineContent(Document document, int line) {
+		try {
+			int lineOffset = document.getLineOffset(line - 1);
+			int lineLength = document.getLineLength(line - 1);
+			return document.get(lineOffset, lineLength);
+		} catch (BadLocationException e) {
+			return null;
+		}
+	}
 }


### PR DESCRIPTION
First step towards fixing the tests with valgrind 3.22.0 as shipped in fedora 39.