### PR TITLE
Fix WrongDeallocationResolutionTest with latest valgrind

### DIFF
--- a/valgrind/org.eclipse.linuxtools.valgrind.ui.tests/resources/wrongDeallocTest/wrongDealloc.cpp
+++ b/valgrind/org.eclipse.linuxtools.valgrind.ui.tests/resources/wrongDeallocTest/wrongDealloc.cpp
@@ -7,20 +7,7 @@ using namespace std;
 
 int main()
 {
-	char *p1 = (char *)malloc(sizeof(char) * SIZE);
-	delete(p1);
-
-	char* p2 = (char *)malloc(5 * sizeof(char) * SIZE);
-	delete[] p2;
-
-	char *p3 = new char;
-	free(p3);
-
-	char *p4 = new char[5];
-	free(p4);
-
-	char* p5 = new char[5];
-	delete p5;
+	__VALGRIND__
 
 	return 0;
 }


### PR DESCRIPTION
Adjust to changes in valgrind output and thus markers generated by the plugin.