### PR TITLE
Include deps of Jersey/Jackson/etc in p2 site

### DIFF
--- a/releng/org.eclipse.linuxtools.docker-site/category.xml
+++ b/releng/org.eclipse.linuxtools.docker-site/category.xml
@@ -58,10 +58,16 @@
    <iu id="com.fasterxml.jackson.module.jackson-module-jaxb-annotations" version="0.0.0">
         <category name="Docker Client Dependencies"/>
    </iu>
+   <iu id="com.fasterxml.jackson.module.jackson-module-jakarta-xmlbind-annotations" version="0.0.0">
+        <category name="Docker Client Dependencies"/>
+   </iu>
    <iu id="jakarta.ws.rs-api" version="0.0.0">
         <category name="Docker Client Dependencies"/>
    </iu>
    <iu id="jakarta.xml.bind-api" version="0.0.0">
+        <category name="Docker Client Dependencies"/>
+   </iu>
+   <iu id="jakarta.activation-api" version="0.0.0">
         <category name="Docker Client Dependencies"/>
    </iu>
    <iu id="com.github.jnr.a64asm" version="0.0.0">


### PR DESCRIPTION
This gets CDT builds working by delivering the required dependencies that became required because of #321 