### PR TITLE
Remove call to System.runFinalization()

### DIFF
--- a/profiling/org.eclipse.linuxtools.profiling.tests/src/org/eclipse/linuxtools/internal/profiling/tests/CProjectHelper.java
+++ b/profiling/org.eclipse.linuxtools.profiling.tests/src/org/eclipse/linuxtools/internal/profiling/tests/CProjectHelper.java
@@ -133,7 +133,6 @@ public class CProjectHelper {
             } finally {
                 try {
                     System.gc();
-                    System.runFinalization();
                     cproject.getProject().delete(true, true, null);
                 } catch (CoreException e2) {
                     fail(getMessage(e2.getStatus()));


### PR DESCRIPTION
It's deprecated for removal and used only in tests.