### PR TITLE
Stop dealing with subclipse stats dialog

### DIFF
--- a/changelog/org.eclipse.linuxtools.changelog.ui.tests/src/org/eclipse/linuxtools/changelog/ui/tests/swtbot/AbstractSWTBotTest.java
+++ b/changelog/org.eclipse.linuxtools.changelog.ui.tests/src/org/eclipse/linuxtools/changelog/ui/tests/swtbot/AbstractSWTBotTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 Red Hat and others.
+ * Copyright (c) 2014, 2024 Red Hat and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -27,15 +27,12 @@ public abstract class AbstractSWTBotTest {
     protected static SWTBotTree projectExplorerViewTree;
 
     @BeforeClass
-    public static void beforeClass() throws Exception {
+	public static void beforeClass() {
         // delay click speed
         //System.setProperty("org.eclipse.swtbot.playback.delay", "200");
         bot = new SWTWorkbenchBot();
         try {
             bot.viewByTitle("Welcome").close();
-            // hide Subclipse Usage stats popup if present/installed
-            bot.shell("Subclipse Usage").activate();
-            bot.button("Cancel").click();
         } catch (WidgetNotFoundException e) {
             // ignore
         }

--- a/perf/org.eclipse.linuxtools.perf.swtbot.tests/src/org/eclipse/linuxtools/internal/perf/swtbot/tests/AbstractSWTBotTest.java
+++ b/perf/org.eclipse.linuxtools.perf.swtbot.tests/src/org/eclipse/linuxtools/internal/perf/swtbot/tests/AbstractSWTBotTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2018 Red Hat Inc.
+ * Copyright (c) 2013, 2024 Red Hat Inc.
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -60,9 +60,6 @@ public abstract class AbstractSWTBotTest extends AbstractTest {
         SWTWorkbenchBot bot = new SWTWorkbenchBot();
         try {
             bot.viewByTitle("Welcome").close();
-            // hide Subclipse Usage stats popup if present/installed
-            bot.shell("Subclipse Usage").activate();
-            bot.button("Cancel").click();
         } catch (WidgetNotFoundException e) {
             // ignore
         }

--- a/profiling/org.eclipse.linuxtools.profiling.provider.tests/src/org/eclipse/linuxtools/profiling/provider/tests/PreferencesTest.java
+++ b/profiling/org.eclipse.linuxtools.profiling.provider.tests/src/org/eclipse/linuxtools/profiling/provider/tests/PreferencesTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2018 Red Hat, Inc.
+ * Copyright (c) 2012, 2024 Red Hat, Inc.
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -107,9 +107,6 @@ public class PreferencesTest extends AbstractTest{
         SWTWorkbenchBot bot = new SWTWorkbenchBot();
         try {
             bot.viewByTitle("Welcome").close(); //$NON-NLS-1$
-            // hide Subclipse Usage stats popup if present/installed
-            bot.shell("Subclipse Usage").activate(); //$NON-NLS-1$
-            bot.button("Cancel").click(); //$NON-NLS-1$
         } catch (WidgetNotFoundException e) {
             // ignore
         }

--- a/systemtap/org.eclipse.linuxtools.systemtap.ui.ide.tests/src/org/eclipse/linuxtools/systemtap/ui/ide/test/swtbot/TestCreateSystemtapScript.java
+++ b/systemtap/org.eclipse.linuxtools.systemtap.ui.ide.tests/src/org/eclipse/linuxtools/systemtap/ui/ide/test/swtbot/TestCreateSystemtapScript.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2018 Red Hat.
+ * Copyright (c) 2013, 2024 Red Hat.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -267,9 +267,6 @@ public class TestCreateSystemtapScript {
 
         try {
             bot.viewByTitle("Welcome").close();
-            // hide Subclipse Usage stats popup if present/installed
-            bot.shell("Subclipse Usage").activate();
-            bot.button("Cancel").click();
         } catch (WidgetNotFoundException e) {
             //ignore
         	e.printStackTrace();


### PR DESCRIPTION
It's not in the target platform for years now so this patch simply reduces noise while trying to stabilize tests.