### PR TITLE
Simplify Process streams handling

### DIFF
--- a/containers/org.eclipse.linuxtools.docker.core/src/org/eclipse/linuxtools/internal/docker/core/ProcessLauncher.java
+++ b/containers/org.eclipse.linuxtools.docker.core/src/org/eclipse/linuxtools/internal/docker/core/ProcessLauncher.java
@@ -16,8 +16,6 @@ package org.eclipse.linuxtools.internal.docker.core;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
@@ -171,9 +169,7 @@ public class ProcessLauncher {
 			process.waitFor();
 			if (process.exitValue() == 0) {
 				final List<String> result = new ArrayList<>();
-				try (final InputStream inputStream = process.getInputStream();
-						final BufferedReader buff = new BufferedReader(
-								new InputStreamReader(inputStream))) {
+				try (final BufferedReader buff = process.inputReader()) {
 					String line;
 					while ((line = buff.readLine()) != null) {
 						result.add(line);
@@ -181,10 +177,8 @@ public class ProcessLauncher {
 				}
 				return result.toArray(new String[0]);
 			} else {
-					final StringBuilder errorMessage = new StringBuilder();
-				try (final InputStream errorStream = process.getErrorStream();
-						final BufferedReader buff = new BufferedReader(
-								new InputStreamReader(errorStream))) {
+				final StringBuilder errorMessage = new StringBuilder();
+				try (final BufferedReader buff = process.errorReader()) {
 					String line;
 					while ((line = buff.readLine()) != null) {
 						errorMessage.append(line).append('\n'); // $NON-NLS-1$

--- a/containers/org.eclipse.linuxtools.docker.editor.ls/src/org/eclipse/linuxtools/docker/editor/ls/InitializeLaunchConfigurations.java
+++ b/containers/org.eclipse.linuxtools.docker.editor.ls/src/org/eclipse/linuxtools/docker/editor/ls/InitializeLaunchConfigurations.java
@@ -12,7 +12,6 @@ package org.eclipse.linuxtools.docker.editor.ls;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
@@ -41,7 +40,7 @@ public class InitializeLaunchConfigurations {
 		BufferedReader reader = null;
 		try {
 			Process p = Runtime.getRuntime().exec(command);
-			reader = new BufferedReader(new InputStreamReader(p.getInputStream()));
+			reader = p.inputReader();
 			res = reader.readLine();
 		} catch (IOException e) {
 			// try other defaults

--- a/gcov/org.eclipse.linuxtools.gcov.core/src/org/eclipse/linuxtools/internal/gcov/parser/CovManager.java
+++ b/gcov/org.eclipse.linuxtools.gcov.core/src/org/eclipse/linuxtools/internal/gcov/parser/CovManager.java
@@ -22,7 +22,6 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -274,7 +273,7 @@ public class CovManager implements Serializable {
                 Process process = Runtime.getRuntime().exec(new String[] {"sh", "-c", "echo $OSTYPE"}); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 
                 String firstLine = null;
-                try (BufferedReader stdout = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+				try (BufferedReader stdout = process.inputReader()) {
                     firstLine = stdout.readLine();
                 }
                 if (firstLine != null) {
@@ -457,14 +456,13 @@ public class CovManager implements Serializable {
         @Override
         public void run() {
             try {
-                populateGCDAFiles(p.getInputStream());
+				populateGCDAFiles(p.inputReader());
             } catch (IOException e) {
             }
         }
 
-        private void populateGCDAFiles(InputStream s) throws IOException {
-            InputStreamReader isr = new InputStreamReader(s);
-            LineNumberReader lnr = new LineNumberReader(isr);
+		private void populateGCDAFiles(BufferedReader r) throws IOException {
+			LineNumberReader lnr = new LineNumberReader(r);
             String line = null;
             while ((line = lnr.readLine()) != null) {
                 if (line.endsWith(".gcda")) //$NON-NLS-1$

--- a/gprof/org.eclipse.linuxtools.gprof.test/src/org/eclipse/linuxtools/internal/gprof/test/GprofTest.java
+++ b/gprof/org.eclipse.linuxtools.gprof.test/src/org/eclipse/linuxtools/internal/gprof/test/GprofTest.java
@@ -17,8 +17,6 @@ import static org.eclipse.linuxtools.internal.gprof.test.STJunitUtils.OUTPUT_FIL
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 import java.util.ArrayList;
 import java.util.List;
@@ -53,9 +51,8 @@ public class GprofTest {
         boolean addr2line2_16 = false;
         try {
             Process p = Runtime.getRuntime().exec("addr2line --version");
-            InputStream is = p.getInputStream();
-            LineNumberReader reader = new LineNumberReader(
-                    new InputStreamReader(is));
+			LineNumberReader reader = new LineNumberReader(
+					p.inputReader());
             String line;
             while ((line = reader.readLine()) != null) {
                 if (line.contains("addr2line 2.16.")) {

--- a/gprof/org.eclipse.linuxtools.gprof/src/org/eclipse/linuxtools/internal/gprof/utils/Aggregator.java
+++ b/gprof/org.eclipse.linuxtools.gprof/src/org/eclipse/linuxtools/internal/gprof/utils/Aggregator.java
@@ -14,7 +14,6 @@ package org.eclipse.linuxtools.internal.gprof.utils;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 
 import org.eclipse.cdt.utils.spawner.ProcessFactory;
@@ -91,7 +90,7 @@ public class Aggregator {
         @Override
         public void run() {
             try {
-                LineNumberReader lnr = new LineNumberReader(new InputStreamReader(p.getErrorStream()));
+				LineNumberReader lnr = new LineNumberReader(p.errorReader());
                 do {
                     String s = lnr.readLine();
                     if (s == null)

--- a/man/org.eclipse.linuxtools.man.core/src/org/eclipse/linuxtools/internal/man/parser/ManParser.java
+++ b/man/org.eclipse.linuxtools.man.core/src/org/eclipse/linuxtools/internal/man/parser/ManParser.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
@@ -124,8 +125,7 @@ public class ManParser {
 			Process process = builder.start();
 			stdout = process.getInputStream();
 		} catch (IOException e) {
-			Bundle bundle = FrameworkUtil.getBundle(this.getClass());
-			Platform.getLog(bundle).log(Status.error(e.getMessage()));
+			ILog.get().log(Status.error(e.getMessage()));
 		}
 		return stdout;
 	}
@@ -148,8 +148,7 @@ public class ManParser {
 				sb.append(reader.lines().collect(Collectors.joining("\n"))); //$NON-NLS-1$
 			}
 		} catch (IOException e) {
-			Bundle bundle = FrameworkUtil.getBundle(this.getClass());
-			Platform.getLog(bundle).log(Status.error(e.getMessage()));
+			ILog.get().log(Status.error(e.getMessage()));
 		}
 		return sb;
 	}

--- a/perf/org.eclipse.linuxtools.perf/src/org/eclipse/linuxtools/internal/perf/AbstractDataManipulator.java
+++ b/perf/org.eclipse.linuxtools.perf/src/org/eclipse/linuxtools/internal/perf/AbstractDataManipulator.java
@@ -85,16 +85,16 @@ public abstract class AbstractDataManipulator extends BaseDataManipulator
 
             switch (fd) {
             case 2:
-                buffData = new BufferedReader(new InputStreamReader(proc.getErrorStream()));
-                buffTemp = new BufferedReader(new InputStreamReader(proc.getInputStream()));
+                buffData = proc.errorReader();
+                buffTemp = proc.inputReader();
                 readStream(buffTemp, temp);
                 readStream(buffData, data);
                 break;
             case 1:
                 // fall through to default case
             default:
-                buffData = new BufferedReader(new InputStreamReader(proc.getInputStream()));
-                buffTemp = new BufferedReader(new InputStreamReader(proc.getErrorStream()));
+                buffData = proc.inputReader();
+                buffTemp = proc.errorReader();
                 readStream(buffData, data);
                 readStream(buffTemp, temp);
                 break;

--- a/perf/org.eclipse.linuxtools.perf/src/org/eclipse/linuxtools/internal/perf/PerfCore.java
+++ b/perf/org.eclipse.linuxtools.perf/src/org/eclipse/linuxtools/internal/perf/PerfCore.java
@@ -14,7 +14,6 @@ package org.eclipse.linuxtools.internal.perf;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.net.URI;
 import java.util.ArrayList;
@@ -167,7 +166,7 @@ public class PerfCore {
              * Old versions of Perf will send events list to stderr instead of stdout
              * Checking if stdout is empty then read from stderr
              */
-            input = new BufferedReader(new InputStreamReader(p.getInputStream()));
+            input = p.inputReader();
 
         } catch( IOException e ) {
             logException(e);
@@ -234,7 +233,7 @@ public class PerfCore {
             return null;
         }
 
-        BufferedReader input = new BufferedReader(new InputStreamReader(p.getInputStream()));
+        BufferedReader input = p.inputReader();
 
         String perfVersion = spitStream(input, "Perf --version", null); //$NON-NLS-1$
         int index = perfVersion.indexOf('-');
@@ -401,8 +400,8 @@ public class PerfCore {
                 PerfPlugin.getDefault().setWorkingDir(workingDir);
             }
 
-            input = new BufferedReader(new InputStreamReader(p.getInputStream()));
-            error = new BufferedReader(new InputStreamReader(p.getErrorStream()));
+            input = p.inputReader();
+            error = p.errorReader();
             //spitting error stream moved to end of while loop, due to commenting of p.waitFor()
         } catch( IOException e ) {
             logException(e);
@@ -590,8 +589,8 @@ public class PerfCore {
                                     al.add(sb.toString());
                                     p = RuntimeProcessFactory.getFactory().exec(al.toArray(new String[]{}), project);
                                 }
-                                input = new BufferedReader(new InputStreamReader(p.getInputStream()));
-                                error = new BufferedReader(new InputStreamReader(p.getErrorStream()));
+                                input = p.inputReader();
+                                error = p.errorReader();
                             } catch (IOException e) {
                                 logException(e);
                             }

--- a/perf/org.eclipse.linuxtools.perf/src/org/eclipse/linuxtools/internal/perf/launch/PerfLaunchConfigDelegate.java
+++ b/perf/org.eclipse.linuxtools.perf/src/org/eclipse/linuxtools/internal/perf/launch/PerfLaunchConfigDelegate.java
@@ -22,7 +22,6 @@ package org.eclipse.linuxtools.internal.perf.launch;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.net.URI;
@@ -163,8 +162,7 @@ public class PerfLaunchConfigDelegate extends AbstractCLaunchDelegate {
                 MessageConsoleStream stream = console.newMessageStream();
 
                 if (pProxy != null) {
-                    try (BufferedReader error = new BufferedReader(
-                            new InputStreamReader(pProxy.getErrorStream()))) {
+                    try (BufferedReader error = pProxy.errorReader()) {
                         String err = error.readLine();
                         while (err != null) {
                             stream.println(err);

--- a/profiling/org.eclipse.linuxtools.binutils/src/org/eclipse/linuxtools/binutils/utils/STNM.java
+++ b/profiling/org.eclipse.linuxtools.binutils/src/org/eclipse/linuxtools/binutils/utils/STNM.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2009, 2018 STMicroelectronics and others.
- * 
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -15,8 +15,6 @@ package org.eclipse.linuxtools.binutils.utils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -66,12 +64,11 @@ public class STNM {
             System.arraycopy(params, 0, args, 1, params.length);
         }
         Process process = CdtSpawnerProcessFactory.getFactory().exec(args, project);
-        parseOutput(process.getInputStream());
+		parseOutput(process.inputReader());
         process.destroy();
     }
 
-    private void parseOutput(InputStream stream) throws IOException {
-        BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
+	private void parseOutput(BufferedReader reader) throws IOException {
         String line;
 
         // See matcher.java for regular expression string data definitions.

--- a/profiling/org.eclipse.linuxtools.tools.launch.core/src/org/eclipse/linuxtools/tools/launch/core/factory/RuntimeProcessFactory.java
+++ b/profiling/org.eclipse.linuxtools.tools.launch.core/src/org/eclipse/linuxtools/tools/launch/core/factory/RuntimeProcessFactory.java
@@ -15,7 +15,6 @@ package org.eclipse.linuxtools.tools.launch.core.factory;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -107,7 +106,7 @@ public class RuntimeProcessFactory extends LinuxtoolsProcessFactory {
 					new NullProgressMonitor());
 			if (pProxy != null) {
 				ArrayList<String> lines = new ArrayList<>();
-				try (BufferedReader reader = new BufferedReader(new InputStreamReader(pProxy.getInputStream()))) {
+				try (BufferedReader reader = pProxy.inputReader()) {
 					String readLine = reader.readLine();
 					while (readLine != null) {
 						lines.add(readLine);

--- a/systemtap/org.eclipse.linuxtools.callgraph.core/src/org/eclipse/linuxtools/internal/callgraph/core/SystemTapView.java
+++ b/systemtap/org.eclipse.linuxtools.callgraph.core/src/org/eclipse/linuxtools/internal/callgraph/core/SystemTapView.java
@@ -18,7 +18,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 
@@ -222,8 +221,7 @@ public abstract class SystemTapView extends ViewPart {
             public void run() {
                 try {
                     Process pr = RuntimeProcessFactory.getFactory().exec("stap -V", null); //$NON-NLS-1$
-                    BufferedReader buf = new BufferedReader(
-                            new InputStreamReader(pr.getErrorStream()));
+					BufferedReader buf = pr.errorReader();
                     String line = ""; //$NON-NLS-1$
                     String message = ""; //$NON-NLS-1$
 

--- a/systemtap/org.eclipse.linuxtools.systemtap.ui.ide/src/org/eclipse/linuxtools/internal/systemtap/ui/ide/preferences/PreferenceInitializer.java
+++ b/systemtap/org.eclipse.linuxtools.systemtap.ui.ide/src/org/eclipse/linuxtools/internal/systemtap/ui/ide/preferences/PreferenceInitializer.java
@@ -16,7 +16,6 @@ package org.eclipse.linuxtools.internal.systemtap.ui.ide.preferences;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStreamReader;
 
 import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
 import org.eclipse.jface.preference.IPreferenceStore;
@@ -68,7 +67,7 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
         String version = ""; //$NON-NLS-1$
         try {
             Process process = RuntimeProcessFactory.getFactory().exec("uname -r", null, null);//$NON-NLS-1$
-            BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+			BufferedReader reader = process.inputReader();
             version = reader.readLine();
         } catch (IOException e) {
             // Could not run uname use an empty String

--- a/vagrant/org.eclipse.linuxtools.vagrant.core/src/org/eclipse/linuxtools/internal/vagrant/core/VagrantConnection.java
+++ b/vagrant/org.eclipse.linuxtools.vagrant.core/src/org/eclipse/linuxtools/internal/vagrant/core/VagrantConnection.java
@@ -16,7 +16,6 @@ import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -438,8 +437,7 @@ public class VagrantConnection implements IVagrantConnection, Closeable {
 			cmd.addAll(Arrays.asList(args));
 			Process p = Runtime.getRuntime().exec(cmd.toArray(new String[0]),
 					envp, vagrantDir);
-			BufferedReader buff = new BufferedReader(
-					new InputStreamReader(p.getInputStream()));
+			BufferedReader buff = p.inputReader();
 			if (p.waitFor() == 0) {
 				String line;
 				while ((line = buff.readLine()) != null) {
@@ -448,8 +446,7 @@ public class VagrantConnection implements IVagrantConnection, Closeable {
 			} else {
 				return new String[0];
 			}
-		} catch (IOException e) {
-		} catch (InterruptedException e) {
+		} catch (IOException | InterruptedException e) {
 		}
 		return result.toArray(new String[0]);
 	}

--- a/valgrind/org.eclipse.linuxtools.valgrind.launch/src/org/eclipse/linuxtools/internal/valgrind/launch/ValgrindRemoteProxyLaunchDelegate.java
+++ b/valgrind/org.eclipse.linuxtools.valgrind.launch/src/org/eclipse/linuxtools/internal/valgrind/launch/ValgrindRemoteProxyLaunchDelegate.java
@@ -17,7 +17,6 @@ package org.eclipse.linuxtools.internal.valgrind.launch;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -73,8 +72,7 @@ public class ValgrindRemoteProxyLaunchDelegate extends ValgrindLaunchConfigurati
             Process p = RuntimeProcessFactory.getFactory().exec(cmdArray,
                     project);
 
-            try (BufferedReader stdout = new BufferedReader(
-                    new InputStreamReader(p.getInputStream()))) {
+            try (BufferedReader stdout = p.inputReader()) {
                 return stdout.readLine();
             }
         } catch (IOException e) {
@@ -237,13 +235,13 @@ public class ValgrindRemoteProxyLaunchDelegate extends ValgrindLaunchConfigurati
                 String line = null;
 
                 StringBuilder valgrindOutSB = new StringBuilder();
-                BufferedReader valgrindOut = new BufferedReader(new InputStreamReader(p.getInputStream()));
+                BufferedReader valgrindOut = p.inputReader();
                 while((line = valgrindOut.readLine()) != null ){
                     valgrindOutSB.append(line);
                 }
 
                 StringBuilder valgrindErrSB = new StringBuilder();
-                BufferedReader valgrindErr = new BufferedReader(new InputStreamReader(p.getErrorStream()));
+                BufferedReader valgrindErr = p.errorReader();
                 while((line = valgrindErr.readLine()) != null ){
                     valgrindErrSB.append(line);
                 }


### PR DESCRIPTION
Use the input/errorReader methods to avoid manual wrapping of the streams.