### PR TITLE
Fix generics warnings

### DIFF
--- a/containers/org.eclipse.linuxtools.docker.ui/src/org/eclipse/linuxtools/internal/docker/ui/launch/RunImageNetworkTab.java
+++ b/containers/org.eclipse.linuxtools.docker.ui/src/org/eclipse/linuxtools/internal/docker/ui/launch/RunImageNetworkTab.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Red Hat Inc. and others.
- * 
+ * Copyright (c) 2017, 2025 Red Hat Inc. and others.
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -215,7 +215,7 @@ public class RunImageNetworkTab extends AbstractLaunchConfigurationTab {
 	private Binding bindButton(final Button button, final String strValue) {
 		return dbc.bindValue(WidgetProperties.widgetSelection().observe(button),
 				BeanProperties.value(ImageRunNetworkModel.class, ImageRunNetworkModel.NETWORK_MODE).observe(model),
-				new UpdateValueStrategy() {
+				new UpdateValueStrategy<>() {
 					@Override
 					public Object convert(Object value) {
 						if (value.equals(Boolean.TRUE)) {
@@ -224,7 +224,7 @@ public class RunImageNetworkTab extends AbstractLaunchConfigurationTab {
 						return null;
 					}
 
-				}, new UpdateValueStrategy() {
+				}, new UpdateValueStrategy<>() {
 					@Override
 					public Object convert(final Object value) {
 						return value.equals(strValue);

--- a/containers/org.eclipse.linuxtools.docker.ui/src/org/eclipse/linuxtools/internal/docker/ui/launch/RunImageResourcesTab.java
+++ b/containers/org.eclipse.linuxtools.docker.ui/src/org/eclipse/linuxtools/internal/docker/ui/launch/RunImageResourcesTab.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 Red Hat Inc. and others.
- * 
+ * Copyright (c) 2015, 2025 Red Hat Inc. and others.
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -201,7 +201,7 @@ public class RunImageResourcesTab extends AbstractLaunchConfigurationTab {
 	/**
 	 * Binds the given <code>cpuShares</code> value to the given {@link Button}
 	 * when it is selected.
-	 * 
+	 *
 	 * @param button
 	 *            the {@link Button} to bind
 	 * @param cpuShares
@@ -214,7 +214,7 @@ public class RunImageResourcesTab extends AbstractLaunchConfigurationTab {
 						.value(ImageRunResourceVolumesVariablesModel.class,
 								ImageRunResourceVolumesVariablesModel.CPU_SHARE_WEIGHT)
 						.observe(model),
-				new UpdateValueStrategy() {
+				new UpdateValueStrategy<>() {
 					@Override
 					public Object convert(Object value) {
 						if (value.equals(Boolean.TRUE)) {
@@ -223,7 +223,7 @@ public class RunImageResourcesTab extends AbstractLaunchConfigurationTab {
 						return 0l;
 					}
 
-				}, new UpdateValueStrategy() {
+				}, new UpdateValueStrategy<>() {
 					@Override
 					public Object convert(final Object value) {
 						return value.equals(cpuShares);

--- a/containers/org.eclipse.linuxtools.docker.ui/src/org/eclipse/linuxtools/internal/docker/ui/launch/RunImageVolumesTab.java
+++ b/containers/org.eclipse.linuxtools.docker.ui/src/org/eclipse/linuxtools/internal/docker/ui/launch/RunImageVolumesTab.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2023 Red Hat Inc. and others.
+ * Copyright (c) 2015, 2025 Red Hat Inc. and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -205,7 +205,7 @@ public class RunImageVolumesTab extends AbstractLaunchConfigurationTab {
 	private void bind(final StructuredViewer viewer,
 			final IObservableList input,
 			final IBeanValueProperty[] labelProperties) {
-		final ObservableListContentProvider contentProvider = new ObservableListContentProvider();
+		final ObservableListContentProvider contentProvider = new ObservableListContentProvider<>();
 		if (viewer.getInput() != null) {
 			viewer.setInput(null);
 		}

--- a/containers/org.eclipse.linuxtools.docker.ui/src/org/eclipse/linuxtools/internal/docker/ui/wizards/ContainerDataVolumeDialog.java
+++ b/containers/org.eclipse.linuxtools.docker.ui/src/org/eclipse/linuxtools/internal/docker/ui/wizards/ContainerDataVolumeDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2020 Red Hat Inc. and others.
+ * Copyright (c) 2015, 2025 Red Hat Inc. and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -310,7 +310,7 @@ public class ContainerDataVolumeDialog extends Dialog {
 		return dbc.bindValue(WidgetProperties.widgetSelection().observe(button),
 				BeanProperties.value(DataVolumeModel.class,
 						DataVolumeModel.MOUNT_TYPE).observe(model),
-				new UpdateValueStrategy() {
+				new UpdateValueStrategy<>() {
 					@Override
 					public Object convert(Object value) {
 						if (value.equals(Boolean.TRUE)) {
@@ -327,7 +327,7 @@ public class ContainerDataVolumeDialog extends Dialog {
 							control.setEnabled(enabled);
 						}
 					}
-				}, new UpdateValueStrategy() {
+				}, new UpdateValueStrategy<>() {
 					@Override
 					public Object convert(final Object value) {
 						if (mountType.equals(value)) {

--- a/containers/org.eclipse.linuxtools.docker.ui/src/org/eclipse/linuxtools/internal/docker/ui/wizards/ContainerEnvironmentVariableDialog.java
+++ b/containers/org.eclipse.linuxtools.docker.ui/src/org/eclipse/linuxtools/internal/docker/ui/wizards/ContainerEnvironmentVariableDialog.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 Red Hat Inc. and others.
- * 
+ * Copyright (c) 2015, 2025 Red Hat Inc. and others.
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -15,7 +15,7 @@ package org.eclipse.linuxtools.internal.docker.ui.wizards;
 
 import org.eclipse.core.databinding.DataBindingContext;
 import org.eclipse.core.databinding.beans.typed.BeanProperties;
-import org.eclipse.core.databinding.observable.value.IValueChangeListener;
+import org.eclipse.core.databinding.observable.value.ValueChangeEvent;
 import org.eclipse.jface.databinding.swt.ISWTObservableValue;
 import org.eclipse.jface.databinding.swt.typed.WidgetProperties;
 import org.eclipse.jface.dialogs.Dialog;
@@ -122,17 +122,13 @@ public class ContainerEnvironmentVariableDialog extends Dialog {
 						EnvironmentVariableModel.VALUE).observe(model));
 
 		variableNameObservable
-				.addValueChangeListener(onEnvironmentVariableSettingsChanged());
+				.addValueChangeListener(this::validateInput);
 		variableValueObservable
-				.addValueChangeListener(onEnvironmentVariableSettingsChanged());
+				.addValueChangeListener(this::validateInput);
 		return container;
 	}
 
-	private IValueChangeListener onEnvironmentVariableSettingsChanged() {
-		return event -> validateInput();
-	}
-
-	private void validateInput() {
+	private void validateInput(@SuppressWarnings("unused") ValueChangeEvent<?> event) {
 		final String variableName = model.getName();
 		final String variableValue = model.getValue();
 		if (variableName == null || variableName.isEmpty()

--- a/containers/org.eclipse.linuxtools.docker.ui/src/org/eclipse/linuxtools/internal/docker/ui/wizards/ContainerLabelVariableDialog.java
+++ b/containers/org.eclipse.linuxtools.docker.ui/src/org/eclipse/linuxtools/internal/docker/ui/wizards/ContainerLabelVariableDialog.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 Red Hat Inc. and others.
- * 
+ * Copyright (c) 2015, 2025 Red Hat Inc. and others.
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -15,7 +15,7 @@ package org.eclipse.linuxtools.internal.docker.ui.wizards;
 
 import org.eclipse.core.databinding.DataBindingContext;
 import org.eclipse.core.databinding.beans.typed.BeanProperties;
-import org.eclipse.core.databinding.observable.value.IValueChangeListener;
+import org.eclipse.core.databinding.observable.value.ValueChangeEvent;
 import org.eclipse.jface.databinding.swt.ISWTObservableValue;
 import org.eclipse.jface.databinding.swt.typed.WidgetProperties;
 import org.eclipse.jface.dialogs.Dialog;
@@ -122,17 +122,13 @@ public class ContainerLabelVariableDialog extends Dialog {
 						LabelVariableModel.VALUE).observe(model));
 
 		variableNameObservable
-				.addValueChangeListener(onLabelVariableSettingsChanged());
+				.addValueChangeListener(this::validateInput);
 		variableValueObservable
-				.addValueChangeListener(onLabelVariableSettingsChanged());
+				.addValueChangeListener(this::validateInput);
 		return container;
 	}
 
-	private IValueChangeListener onLabelVariableSettingsChanged() {
-		return event -> validateInput();
-	}
-
-	private void validateInput() {
+	private void validateInput(@SuppressWarnings("unused") ValueChangeEvent<?> event) {
 		final String variableName = model.getName();
 		if (variableName == null || variableName.isEmpty()) {
 		} else {

--- a/containers/org.eclipse.linuxtools.docker.ui/src/org/eclipse/linuxtools/internal/docker/ui/wizards/ContainerLinkDialog.java
+++ b/containers/org.eclipse.linuxtools.docker.ui/src/org/eclipse/linuxtools/internal/docker/ui/wizards/ContainerLinkDialog.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 Red Hat Inc. and others.
- * 
+ * Copyright (c) 2015, 2025 Red Hat Inc. and others.
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -19,7 +19,7 @@ import java.util.List;
 
 import org.eclipse.core.databinding.DataBindingContext;
 import org.eclipse.core.databinding.beans.typed.BeanProperties;
-import org.eclipse.core.databinding.observable.value.IValueChangeListener;
+import org.eclipse.core.databinding.observable.value.ValueChangeEvent;
 import org.eclipse.jface.databinding.swt.ISWTObservableValue;
 import org.eclipse.jface.databinding.swt.typed.WidgetProperties;
 import org.eclipse.jface.dialogs.Dialog;
@@ -167,13 +167,9 @@ public class ContainerLinkDialog extends Dialog {
 
 		dbc.bindValue(containerAliasObservable, BeanProperties
 				.value(ContainerLinkDialogModel.class, ContainerLinkDialogModel.CONTAINER_ALIAS).observe(model));
-		containerNameObservable.addValueChangeListener(onContainerLinkSettingsChanged());
-		containerAliasObservable.addValueChangeListener(onContainerLinkSettingsChanged());
+		containerNameObservable.addValueChangeListener(this::validateInput);
+		containerAliasObservable.addValueChangeListener(this::validateInput);
 		return container;
-	}
-
-	private IValueChangeListener onContainerLinkSettingsChanged() {
-		return event -> validateInput();
 	}
 
 	public String getContainerName() {
@@ -187,7 +183,7 @@ public class ContainerLinkDialog extends Dialog {
 	/**
 	 * Creates an {@link IContentProposalProvider} to propose
 	 * {@link IDockerContainer} names based on the current text.
-	 * 
+	 *
 	 * @param items
 	 * @return
 	 */
@@ -205,7 +201,7 @@ public class ContainerLinkDialog extends Dialog {
 		};
 	}
 
-	private void validateInput() {
+	private void validateInput(@SuppressWarnings("unused") ValueChangeEvent<?> e) {
 		final String selectedContainerName = model.getContainerName();
 		final Object[] containerNames = model.getContainerNames().toArray();
 		final String containerAlias = model.getContainerAlias();

--- a/containers/org.eclipse.linuxtools.docker.ui/src/org/eclipse/linuxtools/internal/docker/ui/wizards/ContainerPortDialog.java
+++ b/containers/org.eclipse.linuxtools.docker.ui/src/org/eclipse/linuxtools/internal/docker/ui/wizards/ContainerPortDialog.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 Red Hat Inc. and others.
- * 
+ * Copyright (c) 2015, 2025 Red Hat Inc. and others.
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -15,7 +15,7 @@ package org.eclipse.linuxtools.internal.docker.ui.wizards;
 
 import org.eclipse.core.databinding.DataBindingContext;
 import org.eclipse.core.databinding.beans.typed.BeanProperties;
-import org.eclipse.core.databinding.observable.value.IValueChangeListener;
+import org.eclipse.core.databinding.observable.value.ValueChangeEvent;
 import org.eclipse.jface.databinding.swt.ISWTObservableValue;
 import org.eclipse.jface.databinding.swt.typed.WidgetProperties;
 import org.eclipse.jface.dialogs.Dialog;
@@ -147,17 +147,13 @@ public class ContainerPortDialog extends Dialog {
 		dbc.bindValue(hostPortObservable, BeanProperties
 				.value(ContainerPortDialogModel.class, ContainerPortDialogModel.HOST_PORT).observe(model));
 
-		containerPortObservable.addValueChangeListener(onContainerPortSettingsChanged());
-		hostPortObservable.addValueChangeListener(onContainerPortSettingsChanged());
-		hostAddressObservable.addValueChangeListener(onContainerPortSettingsChanged());
+		containerPortObservable.addValueChangeListener(this::validateInput);
+		hostPortObservable.addValueChangeListener(this::validateInput);
+		hostAddressObservable.addValueChangeListener(this::validateInput);
 		return container;
 	}
 
-	private IValueChangeListener onContainerPortSettingsChanged() {
-		return event -> validateInput();
-	}
-
-	private void validateInput() {
+	private void validateInput(@SuppressWarnings("unused") ValueChangeEvent<?> e) {
 		final String containerPort = model.getContainerPort();
 		if (containerPort == null || containerPort.isEmpty()) {
 			setOkButtonEnabled(false);

--- a/containers/org.eclipse.linuxtools.docker.ui/src/org/eclipse/linuxtools/internal/docker/ui/wizards/DockerComposeUpDialog.java
+++ b/containers/org.eclipse.linuxtools.docker.ui/src/org/eclipse/linuxtools/internal/docker/ui/wizards/DockerComposeUpDialog.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 Red Hat Inc. and others.
- * 
+ * Copyright (c) 2015, 2025 Red Hat Inc. and others.
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -60,7 +60,7 @@ public class DockerComposeUpDialog extends Dialog {
 
 	/**
 	 * Constructor.
-	 * 
+	 *
 	 * @param parentShell
 	 *            the parent {@link Shell}
 	 */
@@ -80,7 +80,6 @@ public class DockerComposeUpDialog extends Dialog {
 		return new Point(400, super.getInitialSize().y);
 	}
 
-	@SuppressWarnings("unchecked")
 	@Override
 	protected Control createDialogArea(final Composite parent) {
 		final int COLUMNS = 2;
@@ -125,7 +124,7 @@ public class DockerComposeUpDialog extends Dialog {
 				}, getConnectionNameContentProposalProvider(
 						containerSelectionCombo),
 				null, null);
-		final ISWTObservableValue connnectionNameObservable = WidgetProperties
+		final ISWTObservableValue<?> connnectionNameObservable = WidgetProperties
 				.widgetSelection().observe(connectionSelectionComboViewer.getCombo());
 		// pre-select with first connection
 		if (!connectionNames.isEmpty()) {
@@ -198,7 +197,7 @@ public class DockerComposeUpDialog extends Dialog {
 
 	/**
 	 * Validates that the selected {@link IDockerConnection} exists.
-	 * 
+	 *
 	 * @return a validation status
 	 */
 	private IStatus validateInput() {
@@ -227,7 +226,7 @@ public class DockerComposeUpDialog extends Dialog {
 	/**
 	 * Creates an {@link IContentProposalProvider} to propose
 	 * {@link IDockerContainer} names based on the current text.
-	 * 
+	 *
 	 * @param items
 	 * @return
 	 */

--- a/containers/org.eclipse.linuxtools.docker.ui/src/org/eclipse/linuxtools/internal/docker/ui/wizards/ImageRunNetworkPage.java
+++ b/containers/org.eclipse.linuxtools.docker.ui/src/org/eclipse/linuxtools/internal/docker/ui/wizards/ImageRunNetworkPage.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Red Hat Inc. and others.
- * 
+ * Copyright (c) 2017, 2025 Red Hat Inc. and others.
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -285,14 +285,13 @@ public class ImageRunNetworkPage extends WizardPage {
 	 *            the <code>network mode</code> to bind to the {@link Button}
 	 * @return
 	 */
-	@SuppressWarnings("unchecked")
 	private Binding bindButton(final Button button, final String strValue) {
 		return dbc.bindValue(WidgetProperties.widgetSelection().observe(button),
 				BeanProperties
 						.value(ImageRunNetworkModel.class,
 								ImageRunNetworkModel.NETWORK_MODE)
 						.observe(model),
-				new UpdateValueStrategy() {
+				new UpdateValueStrategy<>() {
 					@Override
 					public Object convert(Object value) {
 						if (value.equals(Boolean.TRUE)) {
@@ -301,7 +300,7 @@ public class ImageRunNetworkPage extends WizardPage {
 						return null;
 					}
 
-				}, new UpdateValueStrategy() {
+				}, new UpdateValueStrategy<>() {
 					@Override
 					public Object convert(final Object value) {
 						return value.equals(strValue);

--- a/containers/org.eclipse.linuxtools.docker.ui/src/org/eclipse/linuxtools/internal/docker/ui/wizards/ImageRunResourceVolumesVariablesPage.java
+++ b/containers/org.eclipse.linuxtools.docker.ui/src/org/eclipse/linuxtools/internal/docker/ui/wizards/ImageRunResourceVolumesVariablesPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 Red Hat Inc. and others.
+ * Copyright (c) 2015, 2025 Red Hat Inc. and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -301,7 +301,7 @@ image);
 						.value(ImageRunResourceVolumesVariablesModel.class,
 								ImageRunResourceVolumesVariablesModel.CPU_SHARE_WEIGHT)
 						.observe(model),
-				new UpdateValueStrategy() {
+				new UpdateValueStrategy<>() {
 					@Override
 					public Object convert(Object value) {
 						if (value.equals(Boolean.TRUE)) {
@@ -310,7 +310,7 @@ image);
 						return 0l;
 					}
 
-				}, new UpdateValueStrategy() {
+				}, new UpdateValueStrategy<>() {
 					@Override
 					public Object convert(final Object value) {
 						return value.equals(cpuShares);

--- a/containers/org.eclipse.linuxtools.docker.ui/src/org/eclipse/linuxtools/internal/docker/ui/wizards/ImageRunSelectionPage.java
+++ b/containers/org.eclipse.linuxtools.docker.ui/src/org/eclipse/linuxtools/internal/docker/ui/wizards/ImageRunSelectionPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 Red Hat Inc. and others.
+ * Copyright (c) 2014, 2025 Red Hat Inc. and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -40,6 +40,7 @@ import org.eclipse.core.databinding.observable.list.IObservableList;
 import org.eclipse.core.databinding.observable.list.WritableList;
 import org.eclipse.core.databinding.observable.value.IObservableValue;
 import org.eclipse.core.databinding.observable.value.IValueChangeListener;
+import org.eclipse.core.databinding.observable.value.ValueChangeEvent;
 import org.eclipse.core.databinding.observable.value.WritableValue;
 import org.eclipse.core.databinding.validation.MultiValidator;
 import org.eclipse.core.databinding.validation.ValidationStatus;
@@ -203,7 +204,7 @@ public class ImageRunSelectionPage extends WizardPage {
 						ImageRunSelectionModel.SELECTED_IMAGE_NAME)
 				.observe(model);
 		imageSelectionObservable
-				.addValueChangeListener(onImageSelectionChange());
+				.addValueChangeListener(this::imageSelectionChange);
 		writeValue = new WritableValue<>("", String.class); //$NON-NLS-1$
 		// setup validation support
 		WizardPageSupport.create(this, dbc);
@@ -212,10 +213,10 @@ public class ImageRunSelectionPage extends WizardPage {
 		final ImageSelectionValidator imageSelectionValidator = new ImageSelectionValidator(
 				imageSelectionObservable);
 		imageSelectionObservable
-			.addValueChangeListener(onImageSelectionChange());
+			.addValueChangeListener(this::imageSelectionChange);
 		dbc.addValidationStatusProvider(imageSelectionValidator);
 		imageSelectionObservable
-				.addValueChangeListener(onImageSelectionChange());
+				.addValueChangeListener(this::imageSelectionChange);
 		final IObservableValue containerNameObservable = BeanProperties
 				.value(ImageRunSelectionModel.class,
 						ImageRunSelectionModel.CONTAINER_NAME)
@@ -730,20 +731,16 @@ public class ImageRunSelectionPage extends WizardPage {
 		};
 	}
 
-	private IValueChangeListener onImageSelectionChange() {
-		return event -> {
-			final IDockerImage selectedImage = model.getSelectedImage();
-			// skip if the selected image does not exist in the local Docker
-			// host
-			if (selectedImage == null) {
-				model.setExposedPorts(
-						Collections.emptyList());
-				return;
-			}
-			final IDockerImageInfo selectedImageInfo = getImageInfo(
-					selectedImage);
-			applyImageInfo(selectedImageInfo);
-		};
+	private void imageSelectionChange(@SuppressWarnings("unused") ValueChangeEvent<?> e) {
+		final IDockerImage selectedImage = model.getSelectedImage();
+		// skip if the selected image does not exist in the local Docker
+		// host
+		if (selectedImage == null) {
+			model.setExposedPorts(Collections.emptyList());
+			return;
+		}
+		final IDockerImageInfo selectedImageInfo = getImageInfo(selectedImage);
+		applyImageInfo(selectedImageInfo);
 	}
 
 	private SelectionListener onPullImage() {


### PR DESCRIPTION
Make some methods returning non-generic listeners to be method references.
Put some <> to let compiler figure it on its own in other places.