### PR TITLE
Update Docker Tooling to use docker-client 9.0.3

### DIFF
--- a/containers/org.eclipse.linuxtools.docker.core/META-INF/MANIFEST.MF
+++ b/containers/org.eclipse.linuxtools.docker.core/META-INF/MANIFEST.MF
@@ -26,5 +26,5 @@ Import-Package: com.fasterxml.jackson.annotation;version="2.10.3",
  jakarta.ws.rs;version="2.0.1",
  jakarta.ws.rs.core;version="2.0.1",
  jakarta.ws.rs.client;version="2.0.1",
- org.glassfish.jersey.apache5.connector
+ org.glassfish.jersey.apache.connector
 Automatic-Module-Name: org.eclipse.linuxtools.docker.core

--- a/containers/org.eclipse.linuxtools.docker.ui.tests/META-INF/MANIFEST.MF
+++ b/containers/org.eclipse.linuxtools.docker.ui.tests/META-INF/MANIFEST.MF
@@ -28,7 +28,7 @@ Require-Bundle: org.eclipse.linuxtools.docker.ui;bundle-version="1.0.0",
  org.eclipse.ui.console;bundle-version="3.6.100",
  org.eclipse.launchbar.ui;bundle-version="2.0.1",
  org.eclipse.launchbar.ui.controls;bundle-version="1.0.0"
-Import-Package: org.glassfish.jersey.apache5.connector,
+Import-Package: org.glassfish.jersey.apache.connector,
  org.slf4j
 Bundle-ClassPath: .
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/releng/org.eclipse.linuxtools.docker-site/category.xml
+++ b/releng/org.eclipse.linuxtools.docker-site/category.xml
@@ -103,7 +103,7 @@
    <iu id="org.glassfish.hk2.utils" version="0.0.0">
         <category name="Docker Client Dependencies"/>
    </iu>
-   <iu id="org.glassfish.jersey.connectors.jersey-apache5-connector" version="0.0.0">
+   <iu id="org.glassfish.jersey.connectors.jersey-apache-connector" version="0.0.0">
         <category name="Docker Client Dependencies"/>
    </iu>
    <iu id="org.glassfish.jersey.core.jersey-client" version="0.0.0">

--- a/releng/org.eclipse.linuxtools.target/linuxtools-latest.target
+++ b/releng/org.eclipse.linuxtools.target/linuxtools-latest.target
@@ -9,7 +9,7 @@
 <unit id="org.aopalliance" version="1.0.0.v20230720-0728"/>
 <unit id="org.codelibs.nekohtml" version="2.1.3.v20240413-0800"/>
 <unit id="org.codelibs.nekohtml.source" version="2.1.3.v20240413-0800"/>
-<unit id="org.apache.httpcomponents.client5.httpclient5" version="5.4.2.v20250203-1000" />
+<unit id="org.apache.httpcomponents.httpclient" version="4.5.14" />
 <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/latest"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
@@ -228,7 +228,7 @@
 			</dependency>
 			<dependency>
 				<groupId>org.glassfish.jersey.connectors</groupId>
-				<artifactId>jersey-apache5-connector</artifactId>
+				<artifactId>jersey-apache-connector</artifactId>
 				<version>3.1.10</version>
 				<type>jar</type>
 			</dependency>
@@ -277,7 +277,7 @@
 			<dependency>
 				<groupId>org.mandas</groupId>
 				<artifactId>docker-client</artifactId>
-				<version>9.0.2</version>
+				<version>9.0.3</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>


### PR DESCRIPTION
- fixes unix socket connection errors and switches back to use HTTP 4