### PR TITLE
Create point release 8.22.1

### DIFF
--- a/changelog/org.eclipse.linuxtools.changelog-feature/feature.xml
+++ b/changelog/org.eclipse.linuxtools.changelog-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.linuxtools.changelog"
       label="%featureName"
-      version="8.22.0.qualifier"
+      version="8.22.1.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/changelog/org.eclipse.linuxtools.changelog-feature/pom.xml
+++ b/changelog/org.eclipse.linuxtools.changelog-feature/pom.xml
@@ -15,12 +15,12 @@
   <parent>
     <artifactId>linuxtools-changelog-parent</artifactId>
     <groupId>org.eclipse.linuxtools.changelog</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.changelog</artifactId>
   <packaging>eclipse-feature</packaging>
-  <version>8.22.0-SNAPSHOT</version>
+  <version>8.22.1-SNAPSHOT</version>
 
   <name>Linux Tools ChangeLog Feature</name>
 

--- a/changelog/org.eclipse.linuxtools.changelog.c-feature/feature.xml
+++ b/changelog/org.eclipse.linuxtools.changelog.c-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.linuxtools.changelog.c"
       label="%featureName"
-      version="8.22.0.qualifier"
+      version="8.22.1.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/changelog/org.eclipse.linuxtools.changelog.c-feature/pom.xml
+++ b/changelog/org.eclipse.linuxtools.changelog.c-feature/pom.xml
@@ -15,12 +15,12 @@
   <parent>
     <artifactId>linuxtools-changelog-parent</artifactId>
     <groupId>org.eclipse.linuxtools.changelog</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.changelog.c</artifactId>
   <packaging>eclipse-feature</packaging>
-  <version>8.22.0-SNAPSHOT</version>
+  <version>8.22.1-SNAPSHOT</version>
 
   <name>Linux Tools ChangeLog Feature for C/C++</name>
 

--- a/changelog/org.eclipse.linuxtools.changelog.core/pom.xml
+++ b/changelog/org.eclipse.linuxtools.changelog.core/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-changelog-parent</artifactId>
     <groupId>org.eclipse.linuxtools.changelog</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.changelog.core</artifactId>

--- a/changelog/org.eclipse.linuxtools.changelog.cparser/pom.xml
+++ b/changelog/org.eclipse.linuxtools.changelog.cparser/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-changelog-parent</artifactId>
     <groupId>org.eclipse.linuxtools.changelog</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.changelog.cparser</artifactId>

--- a/changelog/org.eclipse.linuxtools.changelog.doc/pom.xml
+++ b/changelog/org.eclipse.linuxtools.changelog.doc/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-changelog-parent</artifactId>
     <groupId>org.eclipse.linuxtools.changelog</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.changelog.doc</artifactId>

--- a/changelog/org.eclipse.linuxtools.changelog.java-feature/feature.xml
+++ b/changelog/org.eclipse.linuxtools.changelog.java-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.linuxtools.changelog.java"
       label="%featureName"
-      version="8.22.0.qualifier"
+      version="8.22.1.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/changelog/org.eclipse.linuxtools.changelog.java-feature/pom.xml
+++ b/changelog/org.eclipse.linuxtools.changelog.java-feature/pom.xml
@@ -15,12 +15,12 @@
   <parent>
     <artifactId>linuxtools-changelog-parent</artifactId>
     <groupId>org.eclipse.linuxtools.changelog</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.changelog.java</artifactId>
   <packaging>eclipse-feature</packaging>
-  <version>8.22.0-SNAPSHOT</version>
+  <version>8.22.1-SNAPSHOT</version>
 
   <name>Linux Tools ChangeLog Feature for Java</name>
   

--- a/changelog/org.eclipse.linuxtools.changelog.javaparser/pom.xml
+++ b/changelog/org.eclipse.linuxtools.changelog.javaparser/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-changelog-parent</artifactId>
     <groupId>org.eclipse.linuxtools.changelog</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.changelog.parsers.java</artifactId>

--- a/changelog/org.eclipse.linuxtools.changelog.tests/pom.xml
+++ b/changelog/org.eclipse.linuxtools.changelog.tests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-changelog-parent</artifactId>
     <groupId>org.eclipse.linuxtools.changelog</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.changelog.tests</artifactId>

--- a/changelog/org.eclipse.linuxtools.changelog.ui.tests/pom.xml
+++ b/changelog/org.eclipse.linuxtools.changelog.ui.tests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-changelog-parent</artifactId>
     <groupId>org.eclipse.linuxtools.changelog</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.changelog.ui.tests</artifactId>

--- a/changelog/pom.xml
+++ b/changelog/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.eclipse.linuxtools</groupId>
     <artifactId>linuxtools-parent</artifactId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <groupId>org.eclipse.linuxtools.changelog</groupId>

--- a/containers/org.eclipse.linuxtools.docker-feature/feature.xml
+++ b/containers/org.eclipse.linuxtools.docker-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.linuxtools.docker.feature"
       label="%featureName"
-      version="5.22.0.qualifier"
+      version="5.22.1.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/containers/org.eclipse.linuxtools.docker-feature/pom.xml
+++ b/containers/org.eclipse.linuxtools.docker-feature/pom.xml
@@ -14,12 +14,12 @@
   <parent>
       <groupId>org.eclipse.linuxtools</groupId>
       <artifactId>org.eclipse.linuxtools.docker</artifactId>
-      <version>5.22.0</version>
+      <version>5.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.docker.feature</artifactId>
   <packaging>eclipse-feature</packaging>
-  <version>5.22.0-SNAPSHOT</version>
+  <version>5.22.1-SNAPSHOT</version>
 
   <name>Linux Tools Docker Tooling Feature</name>
 

--- a/containers/org.eclipse.linuxtools.docker.core/META-INF/MANIFEST.MF
+++ b/containers/org.eclipse.linuxtools.docker.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Docker Core Plugin
 Bundle-SymbolicName: org.eclipse.linuxtools.docker.core;singleton:=true
-Bundle-Version: 5.22.0.qualifier
+Bundle-Version: 5.22.1.qualifier
 Bundle-Activator: org.eclipse.linuxtools.docker.core.Activator
 Bundle-Vendor: Eclipse Linux Tools
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.28.0",

--- a/containers/org.eclipse.linuxtools.docker.core/pom.xml
+++ b/containers/org.eclipse.linuxtools.docker.core/pom.xml
@@ -4,10 +4,10 @@
 	<parent>
 		<groupId>org.eclipse.linuxtools</groupId>
 		<artifactId>org.eclipse.linuxtools.docker</artifactId>
-		<version>5.22.0</version>
+		<version>5.22.1</version>
 	</parent>
 	<artifactId>org.eclipse.linuxtools.docker.core</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>5.22.0-SNAPSHOT</version>
+	<version>5.22.1-SNAPSHOT</version>
 
 </project>

--- a/containers/org.eclipse.linuxtools.docker.core/src/org/eclipse/linuxtools/internal/docker/core/DockerClientFactory.java
+++ b/containers/org.eclipse.linuxtools.docker.core/src/org/eclipse/linuxtools/internal/docker/core/DockerClientFactory.java
@@ -57,18 +57,51 @@ public class DockerClientFactory {
 	 * Creates a new {@link DockerClient} from the given
 	 * {@link IDockerConnectionSettings}.
 	 *
-	 * @param connectionSettings
-	 *            the connection settings
-	 * @return the {@link DockerClient} or <code>null</code> if the connection
-	 *         URI (Unix socker path or TCP host) was missing (ie,
-	 *         <code>null</code> or empty)
-	 * @throws DockerCertificateException
-	 *             if the path to Docker certificates is invalid (missing files)
+	 * @param connectionSettings the connection settings
+	 * @param infiniteTimeOut    true if socket read time out should be set to 0
+	 * @return the {@link DockerClient}
+	 * @throws DockerCertificateException if the path to Docker certificates is
+	 *                                    invalid (missing files)
+	 */
+	public DockerClient getClient(final IDockerConnectionSettings connectionSettings, final boolean infiniteTimeOut)
+			throws DockerCertificateException {
+		return getClient(connectionSettings, null, infiniteTimeOut);
+	}
+
+	/**
+	 * Creates a new {@link DockerClient} from the given
+	 * {@link IDockerConnectionSettings}.
+	 *
+	 * @param connectionSettings the connection settings
+	 * @param registryAccount    the registry account or null
+	 * @return the {@link DockerClient} or <code>null</code> if the connection URI
+	 *         (Unix socker path or TCP host) was missing (ie, <code>null</code> or
+	 *         empty)
+	 * @throws DockerCertificateException if the path to Docker certificates is
+	 *                                    invalid (missing files)
 	 */
 	public DockerClient getClient(
 			final IDockerConnectionSettings connectionSettings,
 			final IRegistryAccount registryAccount)
 			throws DockerCertificateException {
+		return getClient(connectionSettings, registryAccount, false);
+	}
+
+	/**
+	 * Creates a new {@link DockerClient} from the given
+	 * {@link IDockerConnectionSettings}.
+	 *
+	 * @param connectionSettings the connection settings
+	 * @param registryAccount    the registry account or null
+	 * @param infiniteTimeOut    true if socket read time out should be set to 0
+	 * @return the {@link DockerClient} or <code>null</code> if the connection URI
+	 *         (Unix socker path or TCP host) was missing (ie, <code>null</code> or
+	 *         empty)
+	 * @throws DockerCertificateException if the path to Docker certificates is
+	 *                                    invalid (missing files)
+	 */
+	public DockerClient getClient(final IDockerConnectionSettings connectionSettings,
+			final IRegistryAccount registryAccount, final boolean infiniteTimeOut) throws DockerCertificateException {
 		final DockerClientBuilder builder = DockerClientBuilder.fromEnv();
 		if (connectionSettings
 				.getType() == BindingType.UNIX_SOCKET_CONNECTION) {
@@ -116,6 +149,9 @@ public class DockerClientFactory {
 		String originalRuntimeDelegate = System.setProperty(
 				runtimeDelegateProperty,
 				"org.glassfish.jersey.internal.RuntimeDelegateImpl"); //$NON-NLS-1$
+		if (infiniteTimeOut) {
+			builder.readTimeoutMillis(0);
+		}
 		DefaultDockerClient dockerClient = builder.build();
 		if (originalClientBuilder == null) {
 			System.clearProperty(clientBuilderProperty);

--- a/containers/org.eclipse.linuxtools.docker.core/src/org/eclipse/linuxtools/internal/docker/core/DockerConnection.java
+++ b/containers/org.eclipse.linuxtools.docker.core/src/org/eclipse/linuxtools/internal/docker/core/DockerConnection.java
@@ -572,7 +572,7 @@ public class DockerConnection
 	 */
 	private DockerClient getClientCopy() throws DockerException {
 		try {
-			return dockerClientFactory.getClient(this.connectionSettings);
+			return dockerClientFactory.getClient(this.connectionSettings, true);
 		} catch (org.mandas.docker.client.exceptions.DockerCertificateException e) {
 			throw new DockerException(NLS.bind(Messages.Open_Connection_Failure,
 					this.name, this.getUri()));

--- a/containers/org.eclipse.linuxtools.docker.docs/META-INF/MANIFEST.MF
+++ b/containers/org.eclipse.linuxtools.docker.docs/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.linuxtools.docker.docs;singleton:=true
-Bundle-Version: 5.22.0.qualifier
+Bundle-Version: 5.22.1.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.help
 Bundle-Localization: plugin

--- a/containers/org.eclipse.linuxtools.docker.docs/pom.xml
+++ b/containers/org.eclipse.linuxtools.docker.docs/pom.xml
@@ -15,11 +15,11 @@
   <parent>
     <artifactId>org.eclipse.linuxtools.docker</artifactId>
     <groupId>org.eclipse.linuxtools</groupId>
-    <version>5.22.0</version>
+    <version>5.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.docker.docs</artifactId>
-  <version>5.22.0-SNAPSHOT</version>
+  <version>5.22.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <name>Linux Tools Docker Tooling Documentation Plug-in</name>

--- a/containers/org.eclipse.linuxtools.docker.editor.ls-feature/feature.xml
+++ b/containers/org.eclipse.linuxtools.docker.editor.ls-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.linuxtools.docker.editor.ls.feature"
       label="%featureName"
-      version="5.22.0.qualifier"
+      version="5.22.1.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/containers/org.eclipse.linuxtools.docker.editor.ls-feature/pom.xml
+++ b/containers/org.eclipse.linuxtools.docker.editor.ls-feature/pom.xml
@@ -14,12 +14,12 @@
   <parent>
       <groupId>org.eclipse.linuxtools</groupId>
       <artifactId>org.eclipse.linuxtools.docker</artifactId>
-      <version>5.22.0</version>
+      <version>5.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.docker.editor.ls.feature</artifactId>
   <packaging>eclipse-feature</packaging>
-  <version>5.22.0-SNAPSHOT</version>
+  <version>5.22.1-SNAPSHOT</version>
 
   <name>Linux Tools Docker Tooling Editor Feature</name>
 

--- a/containers/org.eclipse.linuxtools.docker.editor.ls.tests/pom.xml
+++ b/containers/org.eclipse.linuxtools.docker.editor.ls.tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.linuxtools</groupId>
 		<artifactId>org.eclipse.linuxtools.docker</artifactId>
-		<version>5.22.0</version>
+		<version>5.22.1</version>
 	</parent>
 	<artifactId>org.eclipse.linuxtools.docker.editor.ls.tests</artifactId>
 	<version>1.0.0-SNAPSHOT</version>

--- a/containers/org.eclipse.linuxtools.docker.editor.ls/pom.xml
+++ b/containers/org.eclipse.linuxtools.docker.editor.ls/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.linuxtools</groupId>
 		<artifactId>org.eclipse.linuxtools.docker</artifactId>
-		<version>5.22.0</version>
+		<version>5.22.1</version>
 	</parent>
 	<artifactId>org.eclipse.linuxtools.docker.editor.ls</artifactId>
 	<version>1.0.1-SNAPSHOT</version>

--- a/containers/org.eclipse.linuxtools.docker.integration.tests/pom.xml
+++ b/containers/org.eclipse.linuxtools.docker.integration.tests/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.linuxtools</groupId>
 		<artifactId>org.eclipse.linuxtools.docker</artifactId>
-		<version>5.22.0</version>
+		<version>5.22.1</version>
 	</parent>
 	<artifactId>org.eclipse.linuxtools.docker.integration.tests</artifactId>
 	<version>2.2.0-SNAPSHOT</version>

--- a/containers/org.eclipse.linuxtools.docker.reddeer/pom.xml
+++ b/containers/org.eclipse.linuxtools.docker.reddeer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.linuxtools</groupId>
 		<artifactId>org.eclipse.linuxtools.docker</artifactId>
-		<version>5.22.0</version>
+		<version>5.22.1</version>
 	</parent>	
 	<artifactId>org.eclipse.linuxtools.docker.reddeer</artifactId>
 	<version>2.2.0-SNAPSHOT</version>

--- a/containers/org.eclipse.linuxtools.docker.ui.tests/pom.xml
+++ b/containers/org.eclipse.linuxtools.docker.ui.tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.linuxtools</groupId>
 		<artifactId>org.eclipse.linuxtools.docker</artifactId>
-		<version>5.22.0</version>
+		<version>5.22.1</version>
 	</parent>
 	<artifactId>org.eclipse.linuxtools.docker.ui.tests</artifactId>
 	<version>2.2.0-SNAPSHOT</version>

--- a/containers/org.eclipse.linuxtools.docker.ui/META-INF/MANIFEST.MF
+++ b/containers/org.eclipse.linuxtools.docker.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Docker UI Plug-in
 Bundle-SymbolicName: org.eclipse.linuxtools.docker.ui;singleton:=true
-Bundle-Version: 5.22.0.qualifier
+Bundle-Version: 5.22.1.qualifier
 Bundle-Activator: org.eclipse.linuxtools.docker.ui.Activator
 Bundle-Vendor: Eclipse Linux Tools
 Require-Bundle: org.eclipse.ui,

--- a/containers/org.eclipse.linuxtools.docker.ui/pom.xml
+++ b/containers/org.eclipse.linuxtools.docker.ui/pom.xml
@@ -4,10 +4,10 @@
 	<parent>
 		<groupId>org.eclipse.linuxtools</groupId>
 		<artifactId>org.eclipse.linuxtools.docker</artifactId>
-		<version>5.22.0</version>
+		<version>5.22.1</version>
 	</parent>
 	<artifactId>org.eclipse.linuxtools.docker.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>5.22.0-SNAPSHOT</version>
+	<version>5.22.1-SNAPSHOT</version>
 
 </project>

--- a/containers/org.eclipse.linuxtools.jdt.docker.launcher-feature/feature.xml
+++ b/containers/org.eclipse.linuxtools.jdt.docker.launcher-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.linuxtools.jdt.docker.launcher.feature"
       label="%featureName"
-      version="5.22.0.qualifier"
+      version="5.22.1.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/containers/org.eclipse.linuxtools.jdt.docker.launcher-feature/pom.xml
+++ b/containers/org.eclipse.linuxtools.jdt.docker.launcher-feature/pom.xml
@@ -14,12 +14,12 @@
   <parent>
       <groupId>org.eclipse.linuxtools</groupId>
       <artifactId>org.eclipse.linuxtools.docker</artifactId>
-      <version>5.22.0</version>
+      <version>5.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.jdt.docker.launcher.feature</artifactId>
   <packaging>eclipse-feature</packaging>
-  <version>5.22.0-SNAPSHOT</version>
+  <version>5.22.1-SNAPSHOT</version>
 
   <name>Linux Tools JDT Docker Launch Feature</name>
 

--- a/containers/org.eclipse.linuxtools.jdt.docker.launcher/pom.xml
+++ b/containers/org.eclipse.linuxtools.jdt.docker.launcher/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.linuxtools</groupId>
 		<artifactId>org.eclipse.linuxtools.docker</artifactId>
-		<version>5.22.0</version>
+		<version>5.22.1</version>
 	</parent>
 	<artifactId>org.eclipse.linuxtools.jdt.docker.launcher</artifactId>
 	<version>1.0.0-SNAPSHOT</version>

--- a/containers/pom.xml
+++ b/containers/pom.xml
@@ -2,13 +2,13 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>org.eclipse.linuxtools.docker</artifactId>
-	<version>5.22.0</version>
+	<version>5.22.1</version>
 	<packaging>pom</packaging>
 
         <parent>
           <groupId>org.eclipse.linuxtools</groupId>
           <artifactId>linuxtools-parent</artifactId>
-          <version>8.22.0</version>
+          <version>8.22.1</version>
         </parent>
 
 	<properties>

--- a/gcov/org.eclipse.linuxtools.gcov-feature/feature.xml
+++ b/gcov/org.eclipse.linuxtools.gcov-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.linuxtools.gcov"
       label="%featureName"
-      version="8.22.0.qualifier"
+      version="8.22.1.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/gcov/org.eclipse.linuxtools.gcov-feature/pom.xml
+++ b/gcov/org.eclipse.linuxtools.gcov-feature/pom.xml
@@ -15,12 +15,12 @@
   <parent>
     <artifactId>linuxtools-gcov-parent</artifactId>
     <groupId>org.eclipse.linuxtools.gcov</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.gcov</artifactId>
   <packaging>eclipse-feature</packaging>
-  <version>8.22.0-SNAPSHOT</version>
+  <version>8.22.1-SNAPSHOT</version>
 
   <name>Linux Tools GCov Feature</name>
 

--- a/gcov/org.eclipse.linuxtools.gcov.core/pom.xml
+++ b/gcov/org.eclipse.linuxtools.gcov.core/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-gcov-parent</artifactId>
     <groupId>org.eclipse.linuxtools.gcov</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.gcov.core</artifactId>

--- a/gcov/org.eclipse.linuxtools.gcov.docs/pom.xml
+++ b/gcov/org.eclipse.linuxtools.gcov.docs/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.eclipse.linuxtools.gcov</groupId>
     <artifactId>linuxtools-gcov-parent</artifactId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.gcov.docs</artifactId>

--- a/gcov/org.eclipse.linuxtools.gcov.launch/pom.xml
+++ b/gcov/org.eclipse.linuxtools.gcov.launch/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-gcov-parent</artifactId>
     <groupId>org.eclipse.linuxtools.gcov</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.gcov.launch</artifactId>

--- a/gcov/org.eclipse.linuxtools.gcov.test/pom.xml
+++ b/gcov/org.eclipse.linuxtools.gcov.test/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-gcov-parent</artifactId>
     <groupId>org.eclipse.linuxtools.gcov</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.gcov.test</artifactId>

--- a/gcov/pom.xml
+++ b/gcov/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.eclipse.linuxtools</groupId>
     <artifactId>linuxtools-parent</artifactId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <groupId>org.eclipse.linuxtools.gcov</groupId>

--- a/gprof/org.eclipse.linuxtools.gprof-feature/feature.xml
+++ b/gprof/org.eclipse.linuxtools.gprof-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.linuxtools.gprof.feature"
       label="%featureName"
-      version="8.22.0.qualifier"
+      version="8.22.1.qualifier"
       provider-name="%provider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/gprof/org.eclipse.linuxtools.gprof-feature/pom.xml
+++ b/gprof/org.eclipse.linuxtools.gprof-feature/pom.xml
@@ -15,12 +15,12 @@
   <parent>
     <artifactId>linuxtools-gprof-parent</artifactId>
     <groupId>org.eclipse.linuxtools.gprof</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.gprof.feature</artifactId>
   <packaging>eclipse-feature</packaging>
-  <version>8.22.0-SNAPSHOT</version>
+  <version>8.22.1-SNAPSHOT</version>
 
   <name>Linux Tools GProf Integration Feature</name>
 

--- a/gprof/org.eclipse.linuxtools.gprof.docs/pom.xml
+++ b/gprof/org.eclipse.linuxtools.gprof.docs/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>linuxtools-gprof-parent</artifactId>
     <groupId>org.eclipse.linuxtools.gprof</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.gprof.docs</artifactId>

--- a/gprof/org.eclipse.linuxtools.gprof.launch/pom.xml
+++ b/gprof/org.eclipse.linuxtools.gprof.launch/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-gprof-parent</artifactId>
     <groupId>org.eclipse.linuxtools.gprof</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.gprof.launch</artifactId>

--- a/gprof/org.eclipse.linuxtools.gprof.test/pom.xml
+++ b/gprof/org.eclipse.linuxtools.gprof.test/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-gprof-parent</artifactId>
     <groupId>org.eclipse.linuxtools.gprof</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.gprof.test</artifactId>

--- a/gprof/org.eclipse.linuxtools.gprof/pom.xml
+++ b/gprof/org.eclipse.linuxtools.gprof/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-gprof-parent</artifactId>
     <groupId>org.eclipse.linuxtools.gprof</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.gprof</artifactId>

--- a/gprof/pom.xml
+++ b/gprof/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.eclipse.linuxtools</groupId>
     <artifactId>linuxtools-parent</artifactId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <groupId>org.eclipse.linuxtools.gprof</groupId>

--- a/javadocs/org.eclipse.linuxtools.javadocs-feature/feature.xml
+++ b/javadocs/org.eclipse.linuxtools.javadocs-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.linuxtools.javadocs.feature"
       label="%featureName"
-      version="8.22.0.qualifier"
+      version="8.22.1.qualifier"
       provider-name="%provider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/javadocs/org.eclipse.linuxtools.javadocs-feature/pom.xml
+++ b/javadocs/org.eclipse.linuxtools.javadocs-feature/pom.xml
@@ -15,12 +15,12 @@
   <parent>
     <artifactId>linuxtools-javadocs-parent</artifactId>
     <groupId>org.eclipse.linuxtools.javadocs</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.javadocs.feature</artifactId>
   <packaging>eclipse-feature</packaging>
-  <version>8.22.0-SNAPSHOT</version>
+  <version>8.22.1-SNAPSHOT</version>
   <name>Linux Tools Javadocs Feature</name>
 
 </project>

--- a/javadocs/org.eclipse.linuxtools.javadocs.tests/pom.xml
+++ b/javadocs/org.eclipse.linuxtools.javadocs.tests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-javadocs-parent</artifactId>
     <groupId>org.eclipse.linuxtools.javadocs</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.javadocs.tests</artifactId>

--- a/javadocs/org.eclipse.linuxtools.javadocs/pom.xml
+++ b/javadocs/org.eclipse.linuxtools.javadocs/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-javadocs-parent</artifactId>
     <groupId>org.eclipse.linuxtools.javadocs</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.javadocs</artifactId>

--- a/javadocs/pom.xml
+++ b/javadocs/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.eclipse.linuxtools</groupId>
     <artifactId>linuxtools-parent</artifactId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <groupId>org.eclipse.linuxtools.javadocs</groupId>

--- a/libhover/org.eclipse.linuxtools.cdt.libhover-feature/feature.xml
+++ b/libhover/org.eclipse.linuxtools.cdt.libhover-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.linuxtools.cdt.libhover.feature"
       label="%featureName"
-      version="8.22.0.qualifier"
+      version="8.22.1.qualifier"
       provider-name="%provider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/libhover/org.eclipse.linuxtools.cdt.libhover-feature/pom.xml
+++ b/libhover/org.eclipse.linuxtools.cdt.libhover-feature/pom.xml
@@ -15,12 +15,12 @@
   <parent>
     <artifactId>linuxtools-libhover-parent</artifactId>
     <groupId>org.eclipse.linuxtools.cdt.libhover</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.cdt.libhover.feature</artifactId>
   <packaging>eclipse-feature</packaging>
-  <version>8.22.0-SNAPSHOT</version>
+  <version>8.22.1-SNAPSHOT</version>
 
   <name>Linux Tools Libhover Feature</name>
 

--- a/libhover/org.eclipse.linuxtools.cdt.libhover.devhelp-feature/feature.xml
+++ b/libhover/org.eclipse.linuxtools.cdt.libhover.devhelp-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.linuxtools.cdt.libhover.devhelp.feature"
       label="%featureName"
-      version="8.22.0.qualifier"
+      version="8.22.1.qualifier"
       provider-name="%provider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/libhover/org.eclipse.linuxtools.cdt.libhover.devhelp-feature/pom.xml
+++ b/libhover/org.eclipse.linuxtools.cdt.libhover.devhelp-feature/pom.xml
@@ -15,12 +15,12 @@
   <parent>
     <artifactId>linuxtools-libhover-parent</artifactId>
     <groupId>org.eclipse.linuxtools.cdt.libhover</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.cdt.libhover.devhelp.feature</artifactId>
   <packaging>eclipse-feature</packaging>
-  <version>8.22.0-SNAPSHOT</version>
+  <version>8.22.1-SNAPSHOT</version>
 
   <name>Linux Tools Devhelp Libhover Feature</name>
 

--- a/libhover/org.eclipse.linuxtools.cdt.libhover.devhelp.tests/pom.xml
+++ b/libhover/org.eclipse.linuxtools.cdt.libhover.devhelp.tests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-libhover-parent</artifactId>
     <groupId>org.eclipse.linuxtools.cdt.libhover</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.cdt.libhover.devhelp.tests</artifactId>

--- a/libhover/org.eclipse.linuxtools.cdt.libhover.devhelp/pom.xml
+++ b/libhover/org.eclipse.linuxtools.cdt.libhover.devhelp/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-libhover-parent</artifactId>
     <groupId>org.eclipse.linuxtools.cdt.libhover</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.cdt.libhover.devhelp</artifactId>

--- a/libhover/org.eclipse.linuxtools.cdt.libhover.glibc/pom.xml
+++ b/libhover/org.eclipse.linuxtools.cdt.libhover.glibc/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-libhover-parent</artifactId>
     <groupId>org.eclipse.linuxtools.cdt.libhover</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.cdt.libhover.glibc</artifactId>

--- a/libhover/org.eclipse.linuxtools.cdt.libhover.library.docs/pom.xml
+++ b/libhover/org.eclipse.linuxtools.cdt.libhover.library.docs/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-libhover-parent</artifactId>
     <groupId>org.eclipse.linuxtools.cdt.libhover</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.cdt.libhover.library.docs</artifactId>

--- a/libhover/org.eclipse.linuxtools.cdt.libhover.libstdcxx/pom.xml
+++ b/libhover/org.eclipse.linuxtools.cdt.libhover.libstdcxx/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-libhover-parent</artifactId>
     <groupId>org.eclipse.linuxtools.cdt.libhover</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.cdt.libhover.libstdcxx</artifactId>

--- a/libhover/org.eclipse.linuxtools.cdt.libhover.newlib-feature/feature.xml
+++ b/libhover/org.eclipse.linuxtools.cdt.libhover.newlib-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.linuxtools.cdt.libhover.newlib.feature"
       label="%featureName"
-      version="8.22.0.qualifier"
+      version="8.22.1.qualifier"
       provider-name="%provider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/libhover/org.eclipse.linuxtools.cdt.libhover.newlib-feature/pom.xml
+++ b/libhover/org.eclipse.linuxtools.cdt.libhover.newlib-feature/pom.xml
@@ -15,12 +15,12 @@
   <parent>
     <artifactId>linuxtools-libhover-parent</artifactId>
     <groupId>org.eclipse.linuxtools.cdt.libhover</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.cdt.libhover.newlib.feature</artifactId>
   <packaging>eclipse-feature</packaging>
-  <version>8.22.0-SNAPSHOT</version>
+  <version>8.22.1-SNAPSHOT</version>
 
   <name>Linux Tools Libhover Newlib Feature</name>
 

--- a/libhover/org.eclipse.linuxtools.cdt.libhover.newlib/pom.xml
+++ b/libhover/org.eclipse.linuxtools.cdt.libhover.newlib/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-libhover-parent</artifactId>
     <groupId>org.eclipse.linuxtools.cdt.libhover</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.cdt.libhover.newlib</artifactId>

--- a/libhover/org.eclipse.linuxtools.cdt.libhover.tests/pom.xml
+++ b/libhover/org.eclipse.linuxtools.cdt.libhover.tests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-libhover-parent</artifactId>
     <groupId>org.eclipse.linuxtools.cdt.libhover</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.cdt.libhover.tests</artifactId>

--- a/libhover/org.eclipse.linuxtools.cdt.libhover/pom.xml
+++ b/libhover/org.eclipse.linuxtools.cdt.libhover/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-libhover-parent</artifactId>
     <groupId>org.eclipse.linuxtools.cdt.libhover</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.cdt.libhover</artifactId>

--- a/libhover/pom.xml
+++ b/libhover/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.eclipse.linuxtools</groupId>
     <artifactId>linuxtools-parent</artifactId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <groupId>org.eclipse.linuxtools.cdt.libhover</groupId>

--- a/man/org.eclipse.linuxtools.man-feature/feature.xml
+++ b/man/org.eclipse.linuxtools.man-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.linuxtools.man"
       label="%featureName"
-      version="8.22.0.qualifier"
+      version="8.22.1.qualifier"
       provider-name="%provider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/man/org.eclipse.linuxtools.man-feature/pom.xml
+++ b/man/org.eclipse.linuxtools.man-feature/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.eclipse.linuxtools.man</groupId>
     <artifactId>linuxtools-man-parent</artifactId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.man</artifactId>
   <packaging>eclipse-feature</packaging>
-  <version>8.22.0-SNAPSHOT</version>
+  <version>8.22.1-SNAPSHOT</version>
   
   <name>Linux Tools Man Feature (Incubation)</name>
 

--- a/man/org.eclipse.linuxtools.man.core/pom.xml
+++ b/man/org.eclipse.linuxtools.man.core/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.eclipse.linuxtools.man</groupId>
     <artifactId>linuxtools-man-parent</artifactId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.man.core</artifactId>

--- a/man/org.eclipse.linuxtools.man.help/pom.xml
+++ b/man/org.eclipse.linuxtools.man.help/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.eclipse.linuxtools.man</groupId>
     <artifactId>linuxtools-man-parent</artifactId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.man.help</artifactId>

--- a/man/pom.xml
+++ b/man/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.eclipse.linuxtools</groupId>
     <artifactId>linuxtools-parent</artifactId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <groupId>org.eclipse.linuxtools.man</groupId>

--- a/perf/org.eclipse.linuxtools.perf-feature/feature.xml
+++ b/perf/org.eclipse.linuxtools.perf-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.linuxtools.perf.feature"
       label="%featureName"
-      version="8.22.0.qualifier"
+      version="8.22.1.qualifier"
       provider-name="%provider"
       os="linux"
       license-feature="org.eclipse.license"

--- a/perf/org.eclipse.linuxtools.perf-feature/pom.xml
+++ b/perf/org.eclipse.linuxtools.perf-feature/pom.xml
@@ -15,12 +15,12 @@
   <parent>
     <artifactId>linuxtools-perf-parent</artifactId>
     <groupId>org.eclipse.linuxtools.perf-parent</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.perf.feature</artifactId>
   <packaging>eclipse-feature</packaging>
-  <version>8.22.0-SNAPSHOT</version>
+  <version>8.22.1-SNAPSHOT</version>
 
   <name>Linux Tools Perf Integration Feature</name>
 

--- a/perf/org.eclipse.linuxtools.perf.doc/pom.xml
+++ b/perf/org.eclipse.linuxtools.perf.doc/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>linuxtools-perf-parent</artifactId>
     <groupId>org.eclipse.linuxtools.perf-parent</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.perf.doc</artifactId>

--- a/perf/org.eclipse.linuxtools.perf.remote-feature/feature.xml
+++ b/perf/org.eclipse.linuxtools.perf.remote-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.linuxtools.perf.remote.feature"
       label="%featureName"
-      version="8.22.0.qualifier"
+      version="8.22.1.qualifier"
       provider-name="%provider"
       os="linux"
       license-feature="org.eclipse.license"

--- a/perf/org.eclipse.linuxtools.perf.remote-feature/pom.xml
+++ b/perf/org.eclipse.linuxtools.perf.remote-feature/pom.xml
@@ -15,12 +15,12 @@
   <parent>
     <artifactId>linuxtools-perf-parent</artifactId>
     <groupId>org.eclipse.linuxtools.perf-parent</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.perf.remote.feature</artifactId>
   <packaging>eclipse-feature</packaging>
-  <version>8.22.0-SNAPSHOT</version>
+  <version>8.22.1-SNAPSHOT</version>
 
   <name>Linux Tools Remote Perf Integration Feature</name>
 

--- a/perf/org.eclipse.linuxtools.perf.swtbot.tests/pom.xml
+++ b/perf/org.eclipse.linuxtools.perf.swtbot.tests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-perf-parent</artifactId>
     <groupId>org.eclipse.linuxtools.perf-parent</groupId>
-    <version>7.0.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.perf.swtbot.tests</artifactId>

--- a/perf/org.eclipse.linuxtools.perf.tests/pom.xml
+++ b/perf/org.eclipse.linuxtools.perf.tests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-perf-parent</artifactId>
     <groupId>org.eclipse.linuxtools.perf-parent</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.perf.tests</artifactId>

--- a/perf/org.eclipse.linuxtools.perf/pom.xml
+++ b/perf/org.eclipse.linuxtools.perf/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-perf-parent</artifactId>
     <groupId>org.eclipse.linuxtools.perf-parent</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.perf</artifactId>

--- a/perf/pom.xml
+++ b/perf/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.eclipse.linuxtools</groupId>
     <artifactId>linuxtools-parent</artifactId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <groupId>org.eclipse.linuxtools.perf-parent</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
   <groupId>org.eclipse.linuxtools</groupId>
   <artifactId>linuxtools-parent</artifactId>
-  <version>8.22.0</version>
+  <version>8.22.1</version>
   <packaging>pom</packaging>
 
   <name>Eclipse Linux Tools Parent</name>
@@ -45,8 +45,8 @@
   </distributionManagement>
 
   <properties>
-    <mirror-repo-name>update-8.22.0</mirror-repo-name>
-    <mirror-docker-repo-name>update-docker-5.22.0</mirror-docker-repo-name>
+    <mirror-repo-name>update-8.22.1</mirror-repo-name>
+    <mirror-docker-repo-name>update-docker-5.22.1</mirror-docker-repo-name>
     <tycho-version>5.0.2</tycho-version>
     <tycho.scmUrl>scm:git:https://github.com/eclipse-linuxtools/org.eclipse.linuxtools</tycho.scmUrl>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/profiling/org.eclipse.linuxtools.binutils/pom.xml
+++ b/profiling/org.eclipse.linuxtools.binutils/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-profiling-parent</artifactId>
     <groupId>org.eclipse.linuxtools.profiling</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.binutils</artifactId>

--- a/profiling/org.eclipse.linuxtools.dataviewers-feature/feature.xml
+++ b/profiling/org.eclipse.linuxtools.dataviewers-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.linuxtools.dataviewers.feature"
       label="%featureName"
-      version="8.22.0.qualifier"
+      version="8.22.1.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/profiling/org.eclipse.linuxtools.dataviewers-feature/pom.xml
+++ b/profiling/org.eclipse.linuxtools.dataviewers-feature/pom.xml
@@ -15,12 +15,12 @@
   <parent>
     <artifactId>linuxtools-profiling-parent</artifactId>
     <groupId>org.eclipse.linuxtools.profiling</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.dataviewers.feature</artifactId>
   <packaging>eclipse-feature</packaging>
-  <version>8.22.0-SNAPSHOT</version>
+  <version>8.22.1-SNAPSHOT</version>
 
   <name>Linux Tools Dataviewers Feature</name>
 

--- a/profiling/org.eclipse.linuxtools.dataviewers.charts/pom.xml
+++ b/profiling/org.eclipse.linuxtools.dataviewers.charts/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-profiling-parent</artifactId>
     <groupId>org.eclipse.linuxtools.profiling</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.dataviewers.charts</artifactId>

--- a/profiling/org.eclipse.linuxtools.dataviewers.piechart/pom.xml
+++ b/profiling/org.eclipse.linuxtools.dataviewers.piechart/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-profiling-parent</artifactId>
     <groupId>org.eclipse.linuxtools.profiling</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.dataviewers.piechart</artifactId>

--- a/profiling/org.eclipse.linuxtools.dataviewers/pom.xml
+++ b/profiling/org.eclipse.linuxtools.dataviewers/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-profiling-parent</artifactId>
     <groupId>org.eclipse.linuxtools.profiling</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.dataviewers</artifactId>

--- a/profiling/org.eclipse.linuxtools.profiling-feature/feature.xml
+++ b/profiling/org.eclipse.linuxtools.profiling-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.linuxtools.profiling"
       label="%featureName"
-      version="8.22.0.qualifier"
+      version="8.22.1.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/profiling/org.eclipse.linuxtools.profiling-feature/pom.xml
+++ b/profiling/org.eclipse.linuxtools.profiling-feature/pom.xml
@@ -15,12 +15,12 @@
   <parent>
     <artifactId>linuxtools-profiling-parent</artifactId>
     <groupId>org.eclipse.linuxtools.profiling</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.profiling</artifactId>
   <packaging>eclipse-feature</packaging>
-  <version>8.22.0-SNAPSHOT</version>
+  <version>8.22.1-SNAPSHOT</version>
 
   <name>Linux Tools Profiling Framework Feature</name>
 

--- a/profiling/org.eclipse.linuxtools.profiling.docs/pom.xml
+++ b/profiling/org.eclipse.linuxtools.profiling.docs/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.eclipse.linuxtools.profiling</groupId>
     <artifactId>linuxtools-profiling-parent</artifactId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.profiling.docs</artifactId>

--- a/profiling/org.eclipse.linuxtools.profiling.launch.ui.rdt.proxy/pom.xml
+++ b/profiling/org.eclipse.linuxtools.profiling.launch.ui.rdt.proxy/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>linuxtools-profiling-parent</artifactId>
     <groupId>org.eclipse.linuxtools.profiling</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.profiling.launch.ui.rdt.proxy</artifactId>

--- a/profiling/org.eclipse.linuxtools.profiling.launch/pom.xml
+++ b/profiling/org.eclipse.linuxtools.profiling.launch/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-profiling-parent</artifactId>
     <groupId>org.eclipse.linuxtools.profiling</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.profiling.launch</artifactId>

--- a/profiling/org.eclipse.linuxtools.profiling.provider.tests/pom.xml
+++ b/profiling/org.eclipse.linuxtools.profiling.provider.tests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-profiling-parent</artifactId>
     <groupId>org.eclipse.linuxtools.profiling</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.profiling.provider.tests</artifactId>

--- a/profiling/org.eclipse.linuxtools.profiling.remote-feature/feature.xml
+++ b/profiling/org.eclipse.linuxtools.profiling.remote-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.linuxtools.profiling.remote"
       label="%featureName"
-      version="8.22.0.qualifier"
+      version="8.22.1.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/profiling/org.eclipse.linuxtools.profiling.remote-feature/pom.xml
+++ b/profiling/org.eclipse.linuxtools.profiling.remote-feature/pom.xml
@@ -15,12 +15,12 @@
   <parent>
     <artifactId>linuxtools-profiling-parent</artifactId>
     <groupId>org.eclipse.linuxtools.profiling</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.profiling.remote</artifactId>
   <packaging>eclipse-feature</packaging>
-  <version>8.22.0-SNAPSHOT</version>
+  <version>8.22.1-SNAPSHOT</version>
 
   <name>Linux Tools Profiling Remote Capabilities Feature</name>
 

--- a/profiling/org.eclipse.linuxtools.profiling.tests/pom.xml
+++ b/profiling/org.eclipse.linuxtools.profiling.tests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-profiling-parent</artifactId>
     <groupId>org.eclipse.linuxtools.profiling</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.profiling.tests</artifactId>

--- a/profiling/org.eclipse.linuxtools.profiling.ui.capability/pom.xml
+++ b/profiling/org.eclipse.linuxtools.profiling.ui.capability/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-profiling-parent</artifactId>
     <groupId>org.eclipse.linuxtools.profiling</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.profiling.ui.capability</artifactId>

--- a/profiling/org.eclipse.linuxtools.profiling.ui/pom.xml
+++ b/profiling/org.eclipse.linuxtools.profiling.ui/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-profiling-parent</artifactId>
     <groupId>org.eclipse.linuxtools.profiling</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.profiling.ui</artifactId>

--- a/profiling/org.eclipse.linuxtools.rdt.proxy.tests/META-INF/MANIFEST.MF
+++ b/profiling/org.eclipse.linuxtools.rdt.proxy.tests/META-INF/MANIFEST.MF
@@ -8,7 +8,6 @@ Fragment-Host: org.eclipse.linuxtools.rdt.proxy;bundle-version="2.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: junit-jupiter-api,
  org.eclipse.linuxtools.remote.proxy.tests;bundle-version="1.0.0",
- org.eclipse.ptp.rdt.sync.core;bundle-version="5.0.0",
  org.eclipse.linuxtools.profiling.tests;bundle-version="1.1.0",
  org.eclipse.debug.core;bundle-version="3.10.0",
  org.eclipse.cdt.core;bundle-version="6.0.0"

--- a/profiling/org.eclipse.linuxtools.rdt.proxy.tests/pom.xml
+++ b/profiling/org.eclipse.linuxtools.rdt.proxy.tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>linuxtools-profiling-parent</artifactId>
     <groupId>org.eclipse.linuxtools.profiling</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.rdt.proxy.tests</artifactId>

--- a/profiling/org.eclipse.linuxtools.rdt.proxy.tests/src/org/eclipse/linuxtools/rdt/proxy/tests/FileProxyTest.java
+++ b/profiling/org.eclipse.linuxtools.rdt.proxy.tests/src/org/eclipse/linuxtools/rdt/proxy/tests/FileProxyTest.java
@@ -20,108 +20,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileInfo;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.linuxtools.internal.profiling.launch.LocalFileProxy;
-import org.eclipse.linuxtools.internal.rdt.proxy.RDTFileProxy;
 import org.eclipse.linuxtools.profiling.launch.IRemoteFileProxy;
 import org.eclipse.linuxtools.remote.proxy.tests.AbstractProxyTest;
-import org.eclipse.ptp.rdt.sync.core.SyncConfig;
-import org.eclipse.ptp.rdt.sync.core.exceptions.MissingConnectionException;
-import org.eclipse.remote.core.IRemoteConnection;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("restriction")
 public class FileProxyTest extends AbstractProxyTest {
-
-	@Test
-	public void testRemoteFileProxyOnSyncProject() {
-		IRemoteFileProxy fileProxy = null;
-		try {
-			fileProxy =  proxyManager.getFileProxy(syncProject.getProject());
-			assertInstanceOf(RDTFileProxy.class, fileProxy, "Should have returned a remote launcher");
-		} catch (CoreException e) {
-			fail("Should have returned a launcher: " + e.getCause());
-		}
-		String ds = fileProxy.getDirectorySeparator();
-		assertNotNull(ds);
-
-		SyncConfig config = getSyncConfig(syncProject.getProject());
-		String projectLocation = config.getLocation();
-		assertNotNull(projectLocation);
-		IRemoteConnection conn = null;
-		String connScheme = null;
-		try {
-			conn = config.getRemoteConnection();
-			connScheme = conn.getConnectionType().getScheme();
-		} catch (MissingConnectionException e) {
-			fail("Unabled to get remote connection: " + e.getMessage());
-		}
-
-		/*
-		 *  Test getResource()
-		 */
-		IFileStore fs = fileProxy.getResource(projectLocation);
-		assertNotNull(fs);
-		assertEquals(connScheme, fs.toURI().getScheme(), "Remote connection and FileStore schemes diverge");
-		//assertTrue(fs.fetchInfo().isDirectory());
-
-		fs = fileProxy.getResource("/filenotexits");
-		assertNotNull(fs);
-		IFileInfo fileInfo = fs.fetchInfo();
-		assertNotNull(fileInfo);
-		assertFalse(fileInfo.exists());
-
-		/*
-		 * Test getWorkingDir()
-		 */
-		URI workingDir = fileProxy.getWorkingDir();
-		assertNotNull(workingDir);
-		assertEquals("Remote connection and URI schemes diverge", connScheme, workingDir.getScheme());
-
-		/*
-		 * Test toPath()
-		 */
-		URI uri = null;
-		try {
-			uri = new URI(connScheme, conn.getName(), projectLocation, null, null);
-		} catch (URISyntaxException e) {
-			fail("Failed to build URI for the test: " + e.getMessage());
-		}
-		assertEquals(projectLocation, fileProxy.toPath(uri));
-
-		/*
-		 * Test it opens connection
-		 */
-		assertNotNull(conn);
-		conn.close();
-		assertFalse(conn.isOpen());
-		try {
-			fileProxy =  proxyManager.getFileProxy(syncProject.getProject());
-			assertNotNull(fileProxy);
-		} catch (CoreException e) {
-			fail("Failed to obtain file proxy when connection is closed: " + e.getMessage());
-		}
-		fs = fileProxy.getResource("/tmp/somedir");
-		assertNotNull(fs);
-		assertFalse(fs.fetchInfo().exists());
-		try {
-			fs.mkdir(EFS.SHALLOW, new NullProgressMonitor());
-		} catch (CoreException e) {
-			fail("should be able to create a directory when connection is closed: " + e.getMessage());
-		}
-		assertTrue(fs.fetchInfo().exists());
-		try {
-			fs.delete(EFS.NONE, new NullProgressMonitor());
-		} catch (CoreException e) {
-			fail("Failed to delete file: " + e.getMessage());
-		}
-	}
 
 	@Test
 	public void testLocalFileProxy() {

--- a/profiling/org.eclipse.linuxtools.rdt.proxy.tests/src/org/eclipse/linuxtools/rdt/proxy/tests/RemoteProxyManagerTest.java
+++ b/profiling/org.eclipse.linuxtools.rdt.proxy.tests/src/org/eclipse/linuxtools/rdt/proxy/tests/RemoteProxyManagerTest.java
@@ -12,10 +12,9 @@
  *******************************************************************************/
 package org.eclipse.linuxtools.rdt.proxy.tests;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -31,7 +30,6 @@ import org.eclipse.linuxtools.internal.ssh.proxy.SSHFileProxy;
 import org.eclipse.linuxtools.profiling.launch.IRemoteCommandLauncher;
 import org.eclipse.linuxtools.profiling.launch.IRemoteFileProxy;
 import org.eclipse.linuxtools.remote.proxy.tests.AbstractProxyTest;
-import org.eclipse.ptp.rdt.sync.core.SyncConfig;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("restriction")
@@ -148,17 +146,4 @@ public class RemoteProxyManagerTest extends AbstractProxyTest {
 		assertThrows(CoreException.class, ()-> proxyManager.getOS(URI.create("remotetools://MyConnection/path/to/file")),"remotetools scheme should not be recognized");
 	}
 
-	@Test
-	public void testGetRemoteProjectLocationOnSyncProj() {
-		try {
-			String actualLocation = proxyManager.getRemoteProjectLocation(syncProject.getProject());
-			SyncConfig config = getSyncConfig(syncProject.getProject());
-			assertNotNull(config);
-			assertEquals(connection.getConnectionType().getScheme(), URI.create(actualLocation).getScheme());
-			assertEquals(config.getConnectionName(), URI.create(actualLocation).getAuthority());
-			assertEquals(config.getLocation(),URI.create(actualLocation).getPath());
-		} catch (CoreException e) {
-			fail("Should have returned the remote project location: " + e.getMessage());
-		}
-	}
 }

--- a/profiling/org.eclipse.linuxtools.rdt.proxy/pom.xml
+++ b/profiling/org.eclipse.linuxtools.rdt.proxy/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-profiling-parent</artifactId>
     <groupId>org.eclipse.linuxtools.profiling</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.rdt.proxy</artifactId>

--- a/profiling/org.eclipse.linuxtools.remote.proxy.tests/META-INF/MANIFEST.MF
+++ b/profiling/org.eclipse.linuxtools.remote.proxy.tests/META-INF/MANIFEST.MF
@@ -11,10 +11,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,
  org.eclipse.linuxtools.profiling.tests;bundle-version="1.1.0",
  org.eclipse.debug.core,
- org.eclipse.cdt.core,
- org.eclipse.core.filesystem,
- org.eclipse.ptp.rdt.sync.core,
- org.eclipse.ptp.rdt.sync.git.core;bundle-version="2.0.0"
+ org.eclipse.cdt.core
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.linuxtools.remote.proxy.tests;

--- a/profiling/org.eclipse.linuxtools.remote.proxy.tests/pom.xml
+++ b/profiling/org.eclipse.linuxtools.remote.proxy.tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>linuxtools-profiling-parent</artifactId>
     <groupId>org.eclipse.linuxtools.profiling</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.remote.proxy.tests</artifactId>

--- a/profiling/org.eclipse.linuxtools.remote.proxy.tests/src/org/eclipse/linuxtools/remote/proxy/tests/AbstractProxyTest.java
+++ b/profiling/org.eclipse.linuxtools.remote.proxy.tests/src/org/eclipse/linuxtools/remote/proxy/tests/AbstractProxyTest.java
@@ -12,12 +12,6 @@
  *******************************************************************************/
 package org.eclipse.linuxtools.remote.proxy.tests;
 
-import org.eclipse.core.resources.IProject;
-import org.eclipse.ptp.rdt.sync.core.SyncConfig;
-import org.eclipse.ptp.rdt.sync.core.SyncConfigManager;
-import org.eclipse.ptp.rdt.sync.core.SyncFlag;
-import org.eclipse.ptp.rdt.sync.core.SyncManager;
-
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -67,32 +61,6 @@ public abstract class AbstractProxyTest extends AbstractRemoteTest {
 		}
 	}
 
-    /**
-     * Prepare a sync project from an already available local project
-     *
-     * @param project any local project
-     * @param conn remote connection
-     * @param location sync'ed folder path in remote machine
-     * @throws CoreException
-     */
-    protected static void convertToSyncProject(IProject project, IRemoteConnection conn, String location) throws CoreException {
-        // Convert to sync project without file filters
-        SyncManager.makeSyncProject(project, conn.getName() + "_sync", SYNC_SERVICE_GIT, conn, location, null);
-        // Synchronize project from local to remote
-        SyncManager.sync(null, project, SyncFlag.LR_ONLY, null);
-    }
-
-    /**
-     * Get the *active* synchronize configuration associated with the project
-     *
-     * @param project A sync project
-     * @return the active synchronize configuration
-     */
-    protected static SyncConfig getSyncConfig(IProject project) {
-        return SyncConfigManager.getActive(project);
-    }
-
-
 	@Override
 	public ILaunchConfigurationType getLaunchConfigType() {
 		// This testsuite does not care about LaunchConfig
@@ -118,7 +86,6 @@ public abstract class AbstractProxyTest extends AbstractRemoteTest {
 			ICProject project = null;
 			try {
 				project = createProject(Platform.getBundle(PLUGIN), "syncTestProject");
-				convertToSyncProject(project.getProject(), connection, "/tmp/" + PLUGIN);
 			} catch (Exception e) {
 				fail("Failed to create synchronized project for the tests: " + e.getMessage());
 			}

--- a/profiling/org.eclipse.linuxtools.ssh.proxy/pom.xml
+++ b/profiling/org.eclipse.linuxtools.ssh.proxy/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-profiling-parent</artifactId>
     <groupId>org.eclipse.linuxtools.profiling</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.ssh.proxy</artifactId>

--- a/profiling/org.eclipse.linuxtools.tools.launch.core.tests/pom.xml
+++ b/profiling/org.eclipse.linuxtools.tools.launch.core.tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>linuxtools-profiling-parent</artifactId>
     <groupId>org.eclipse.linuxtools.profiling</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.tools.launch.core.tests</artifactId>

--- a/profiling/org.eclipse.linuxtools.tools.launch.core/pom.xml
+++ b/profiling/org.eclipse.linuxtools.tools.launch.core/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-profiling-parent</artifactId>
     <groupId>org.eclipse.linuxtools.profiling</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.tools.launch.core</artifactId>

--- a/profiling/org.eclipse.linuxtools.tools.launch.ui/pom.xml
+++ b/profiling/org.eclipse.linuxtools.tools.launch.ui/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-profiling-parent</artifactId>
     <groupId>org.eclipse.linuxtools.profiling</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.tools.launch.ui</artifactId>

--- a/profiling/pom.xml
+++ b/profiling/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.eclipse.linuxtools</groupId>
     <artifactId>linuxtools-parent</artifactId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <groupId>org.eclipse.linuxtools.profiling</groupId>

--- a/releng/org.eclipse.linuxtools.docker-site/pom.xml
+++ b/releng/org.eclipse.linuxtools.docker-site/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>org.eclipse.linuxtools.releng</groupId>
 		<artifactId>linuxtools-releng-parent</artifactId>
-		<version>8.22.0</version>
+		<version>8.22.1</version>
 	</parent>
 	<artifactId>org.eclipse.linuxtools.docker-site</artifactId>
 	<packaging>eclipse-repository</packaging>

--- a/releng/org.eclipse.linuxtools.releng-site/pom.xml
+++ b/releng/org.eclipse.linuxtools.releng-site/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>org.eclipse.linuxtools.releng</groupId>
 		<artifactId>linuxtools-releng-parent</artifactId>
-		<version>8.22.0</version>
+		<version>8.22.1</version>
 	</parent>
 	<artifactId>org.eclipse.linuxtools.releng-site</artifactId>
 	<packaging>eclipse-repository</packaging>

--- a/releng/org.eclipse.linuxtools.target/linuxtools-latest.target
+++ b/releng/org.eclipse.linuxtools.target/linuxtools-latest.target
@@ -10,7 +10,7 @@
 <unit id="org.codelibs.nekohtml" version="3.0.2.v20251220-1000"/>
 <unit id="org.codelibs.nekohtml.source" version="3.0.2.v20251220-1000"/>
 <unit id="org.apache.httpcomponents.httpclient" version="4.5.14" />
-<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/latest"/>
+<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.39.0"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.jdt.annotation" version="0.0.0"/>
@@ -37,7 +37,7 @@
 <unit id="bcprov" version="0.0.0"/>
 <unit id="bcutil" version="0.0.0"/>
 <unit id="org.eclipse.terminal.feature.feature.group" version="0.0.0"/>
-<repository location="https://download.eclipse.org/eclipse/updates/I-builds/"/>
+<repository location="https://download.eclipse.org/eclipse/updates/4.39/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.license.feature.group" version="0.0.0"/>
@@ -55,14 +55,12 @@
 <repository location="https://download.eclipse.org/tools/cdt/builds/cdt/main/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.dstore.core" version="0.0.0"/>
 <unit id="org.eclipse.jgit.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.ptp.rdt.sync.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.zest.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.lsp4e" version="0.0.0"/>
 <unit id="org.eclipse.tm4e.feature.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.tm4e.language_pack.feature.feature.group" version="0.0.0"/>
-<repository location="https://download.eclipse.org/releases/latest/"/>
+<repository location="https://download.eclipse.org/releases/2026-03/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.eclipse.linuxtools</groupId>
     <artifactId>linuxtools-parent</artifactId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <groupId>org.eclipse.linuxtools.releng</groupId>

--- a/rpm/org.eclipse.linuxtools.rpm-feature/feature.xml
+++ b/rpm/org.eclipse.linuxtools.rpm-feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.linuxtools.rpm"
       label="%featureName"
-      version="8.22.0.qualifier"
+      version="8.22.1.qualifier"
       provider-name="%provider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/rpm/org.eclipse.linuxtools.rpm-feature/pom.xml
+++ b/rpm/org.eclipse.linuxtools.rpm-feature/pom.xml
@@ -15,12 +15,12 @@
   <parent>
     <artifactId>linuxtools-rpm-parent</artifactId>
     <groupId>org.eclipse.linuxtools.rpm</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.rpm</artifactId>
   <packaging>eclipse-feature</packaging>
-  <version>8.22.0-SNAPSHOT</version>
+  <version>8.22.1-SNAPSHOT</version>
 
   <name>Linux Tools RPM Tools Feature</name>
 

--- a/rpm/org.eclipse.linuxtools.rpm.core.tests/pom.xml
+++ b/rpm/org.eclipse.linuxtools.rpm.core.tests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-rpm-parent</artifactId>
     <groupId>org.eclipse.linuxtools.rpm</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.rpm.core.tests</artifactId>

--- a/rpm/org.eclipse.linuxtools.rpm.core/pom.xml
+++ b/rpm/org.eclipse.linuxtools.rpm.core/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-rpm-parent</artifactId>
     <groupId>org.eclipse.linuxtools.rpm</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.rpm.core</artifactId>

--- a/rpm/org.eclipse.linuxtools.rpm.rpmlint/pom.xml
+++ b/rpm/org.eclipse.linuxtools.rpm.rpmlint/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-rpm-parent</artifactId>
     <groupId>org.eclipse.linuxtools.rpm</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.rpm.rpmlint</artifactId>

--- a/rpm/org.eclipse.linuxtools.rpm.ui.editor.doc/pom.xml
+++ b/rpm/org.eclipse.linuxtools.rpm.ui.editor.doc/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-rpm-parent</artifactId>
     <groupId>org.eclipse.linuxtools.rpm</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.rpm.ui.editor.doc</artifactId>

--- a/rpm/org.eclipse.linuxtools.rpm.ui.editor.tests/pom.xml
+++ b/rpm/org.eclipse.linuxtools.rpm.ui.editor.tests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-rpm-parent</artifactId>
     <groupId>org.eclipse.linuxtools.rpm</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.rpm.ui.editor.tests</artifactId>

--- a/rpm/org.eclipse.linuxtools.rpm.ui.editor/pom.xml
+++ b/rpm/org.eclipse.linuxtools.rpm.ui.editor/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-rpm-parent</artifactId>
     <groupId>org.eclipse.linuxtools.rpm</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.rpm.ui.editor</artifactId>

--- a/rpm/org.eclipse.linuxtools.rpm.ui/pom.xml
+++ b/rpm/org.eclipse.linuxtools.rpm.ui/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-rpm-parent</artifactId>
     <groupId>org.eclipse.linuxtools.rpm</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.rpm.ui</artifactId>

--- a/rpm/pom.xml
+++ b/rpm/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.eclipse.linuxtools</groupId>
     <artifactId>linuxtools-parent</artifactId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <groupId>org.eclipse.linuxtools.rpm</groupId>

--- a/systemtap/org.eclipse.linuxtools.callgraph-feature/feature.xml
+++ b/systemtap/org.eclipse.linuxtools.callgraph-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.linuxtools.callgraph.feature"
       label="%featureName"
-      version="8.22.0.qualifier"
+      version="8.22.1.qualifier"
       provider-name="%featureProvider"
       os="linux"
       license-feature="org.eclipse.license"

--- a/systemtap/org.eclipse.linuxtools.callgraph-feature/pom.xml
+++ b/systemtap/org.eclipse.linuxtools.callgraph-feature/pom.xml
@@ -14,12 +14,12 @@
   <parent>
     <artifactId>linuxtools-systemtap-parent</artifactId>
     <groupId>org.eclipse.linuxtools.systemtap</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.callgraph.feature</artifactId>
   <packaging>eclipse-feature</packaging>
-  <version>8.22.0-SNAPSHOT</version>
+  <version>8.22.1-SNAPSHOT</version>
 
   <name>Linux Tools C/C++ Call Graph Visualization Feature</name>
 

--- a/systemtap/org.eclipse.linuxtools.callgraph.core/pom.xml
+++ b/systemtap/org.eclipse.linuxtools.callgraph.core/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-systemtap-parent</artifactId>
     <groupId>org.eclipse.linuxtools.systemtap</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.callgraph.core</artifactId>

--- a/systemtap/org.eclipse.linuxtools.callgraph.docs/pom.xml
+++ b/systemtap/org.eclipse.linuxtools.callgraph.docs/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>linuxtools-systemtap-parent</artifactId>
     <groupId>org.eclipse.linuxtools.systemtap</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.callgraph.docs</artifactId>

--- a/systemtap/org.eclipse.linuxtools.callgraph.launch.tests/pom.xml
+++ b/systemtap/org.eclipse.linuxtools.callgraph.launch.tests/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>linuxtools-systemtap-parent</artifactId>
     <groupId>org.eclipse.linuxtools.systemtap</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.callgraph.launch.tests</artifactId>

--- a/systemtap/org.eclipse.linuxtools.callgraph.launch/pom.xml
+++ b/systemtap/org.eclipse.linuxtools.callgraph.launch/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-systemtap-parent</artifactId>
     <groupId>org.eclipse.linuxtools.systemtap</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.callgraph.launch</artifactId>

--- a/systemtap/org.eclipse.linuxtools.callgraph.tests/pom.xml
+++ b/systemtap/org.eclipse.linuxtools.callgraph.tests/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>linuxtools-systemtap-parent</artifactId>
     <groupId>org.eclipse.linuxtools.systemtap</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.callgraph.tests</artifactId>

--- a/systemtap/org.eclipse.linuxtools.callgraph/pom.xml
+++ b/systemtap/org.eclipse.linuxtools.callgraph/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-systemtap-parent</artifactId>
     <groupId>org.eclipse.linuxtools.systemtap</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.callgraph</artifactId>

--- a/systemtap/org.eclipse.linuxtools.systemtap-feature/feature.xml
+++ b/systemtap/org.eclipse.linuxtools.systemtap-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.linuxtools.systemtap"
       label="%description"
-      version="8.22.0.qualifier"
+      version="8.22.1.qualifier"
       provider-name="%featureProvider"
       os="linux"
       license-feature="org.eclipse.license"

--- a/systemtap/org.eclipse.linuxtools.systemtap-feature/pom.xml
+++ b/systemtap/org.eclipse.linuxtools.systemtap-feature/pom.xml
@@ -14,12 +14,12 @@
   <parent>
     <artifactId>linuxtools-systemtap-parent</artifactId>
     <groupId>org.eclipse.linuxtools.systemtap</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.systemtap</artifactId>
   <packaging>eclipse-feature</packaging>
-  <version>8.22.0-SNAPSHOT</version>
+  <version>8.22.1-SNAPSHOT</version>
 
   <name>Linux Tools SystemTap IDE and Visualization Tools Feature</name>
 

--- a/systemtap/org.eclipse.linuxtools.systemtap.graphing.core.tests/pom.xml
+++ b/systemtap/org.eclipse.linuxtools.systemtap.graphing.core.tests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-systemtap-parent</artifactId>
     <groupId>org.eclipse.linuxtools.systemtap</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.systemtap.graphing.core.tests</artifactId>

--- a/systemtap/org.eclipse.linuxtools.systemtap.graphing.core/pom.xml
+++ b/systemtap/org.eclipse.linuxtools.systemtap.graphing.core/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-systemtap-parent</artifactId>
     <groupId>org.eclipse.linuxtools.systemtap</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.systemtap.graphing.core</artifactId>

--- a/systemtap/org.eclipse.linuxtools.systemtap.graphing.ui/pom.xml
+++ b/systemtap/org.eclipse.linuxtools.systemtap.graphing.ui/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-systemtap-parent</artifactId>
     <groupId>org.eclipse.linuxtools.systemtap</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.systemtap.graphing.ui</artifactId>

--- a/systemtap/org.eclipse.linuxtools.systemtap.structures.tests/pom.xml
+++ b/systemtap/org.eclipse.linuxtools.systemtap.structures.tests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-systemtap-parent</artifactId>
     <groupId>org.eclipse.linuxtools.systemtap</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.systemtap.structures.tests</artifactId>

--- a/systemtap/org.eclipse.linuxtools.systemtap.structures/pom.xml
+++ b/systemtap/org.eclipse.linuxtools.systemtap.structures/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-systemtap-parent</artifactId>
     <groupId>org.eclipse.linuxtools.systemtap</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.systemtap.structures</artifactId>

--- a/systemtap/org.eclipse.linuxtools.systemtap.ui.consolelog.tests/pom.xml
+++ b/systemtap/org.eclipse.linuxtools.systemtap.ui.consolelog.tests/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>linuxtools-systemtap-parent</artifactId>
     <groupId>org.eclipse.linuxtools.systemtap</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.systemtap.ui.consolelog.tests</artifactId>

--- a/systemtap/org.eclipse.linuxtools.systemtap.ui.consolelog/pom.xml
+++ b/systemtap/org.eclipse.linuxtools.systemtap.ui.consolelog/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>linuxtools-systemtap-parent</artifactId>
     <groupId>org.eclipse.linuxtools.systemtap</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.systemtap.ui.consolelog</artifactId>

--- a/systemtap/org.eclipse.linuxtools.systemtap.ui.doc/pom.xml
+++ b/systemtap/org.eclipse.linuxtools.systemtap.ui.doc/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-systemtap-parent</artifactId>
     <groupId>org.eclipse.linuxtools.systemtap</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.systemtap.ui.doc</artifactId>

--- a/systemtap/org.eclipse.linuxtools.systemtap.ui.ide.tests/pom.xml
+++ b/systemtap/org.eclipse.linuxtools.systemtap.ui.ide.tests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-systemtap-parent</artifactId>
     <groupId>org.eclipse.linuxtools.systemtap</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.systemtap.ui.ide.tests</artifactId>

--- a/systemtap/org.eclipse.linuxtools.systemtap.ui.ide/pom.xml
+++ b/systemtap/org.eclipse.linuxtools.systemtap.ui.ide/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-systemtap-parent</artifactId>
     <groupId>org.eclipse.linuxtools.systemtap</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.systemtap.ui.ide</artifactId>

--- a/systemtap/pom.xml
+++ b/systemtap/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.linuxtools</groupId>
     <artifactId>linuxtools-parent</artifactId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <groupId>org.eclipse.linuxtools.systemtap</groupId>

--- a/vagrant/org.eclipse.linuxtools.vagrant-feature/feature.xml
+++ b/vagrant/org.eclipse.linuxtools.vagrant-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.linuxtools.vagrant.feature"
       label="%featureName"
-      version="5.22.0.qualifier"
+      version="5.22.1.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/vagrant/org.eclipse.linuxtools.vagrant-feature/pom.xml
+++ b/vagrant/org.eclipse.linuxtools.vagrant-feature/pom.xml
@@ -14,12 +14,12 @@
   <parent>
       <groupId>org.eclipse.linuxtools</groupId>
       <artifactId>org.eclipse.linuxtools.vagrant</artifactId>
-      <version>5.22.0</version>
+      <version>5.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.vagrant.feature</artifactId>
   <packaging>eclipse-feature</packaging>
-  <version>5.22.0-SNAPSHOT</version>
+  <version>5.22.1-SNAPSHOT</version>
 
   <name>Linux Tools Vagrant Tooling Feature</name>
 

--- a/vagrant/org.eclipse.linuxtools.vagrant.core/pom.xml
+++ b/vagrant/org.eclipse.linuxtools.vagrant.core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.linuxtools</groupId>
 		<artifactId>org.eclipse.linuxtools.vagrant</artifactId>
-		<version>5.22.0</version>
+		<version>5.22.1</version>
 	</parent>
 	<artifactId>org.eclipse.linuxtools.vagrant.core</artifactId>
 	<version>2.0.0-SNAPSHOT</version>

--- a/vagrant/org.eclipse.linuxtools.vagrant.docs/pom.xml
+++ b/vagrant/org.eclipse.linuxtools.vagrant.docs/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>org.eclipse.linuxtools.vagrant</artifactId>
     <groupId>org.eclipse.linuxtools</groupId>
-    <version>5.22.0</version>
+    <version>5.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.vagrant.docs</artifactId>

--- a/vagrant/org.eclipse.linuxtools.vagrant.ui/pom.xml
+++ b/vagrant/org.eclipse.linuxtools.vagrant.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.linuxtools</groupId>
 		<artifactId>org.eclipse.linuxtools.vagrant</artifactId>
-		<version>5.22.0</version>
+		<version>5.22.1</version>
 	</parent>
 	<artifactId>org.eclipse.linuxtools.vagrant.ui</artifactId>
 	<version>2.0.0-SNAPSHOT</version>

--- a/vagrant/pom.xml
+++ b/vagrant/pom.xml
@@ -2,13 +2,13 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>org.eclipse.linuxtools.vagrant</artifactId>
-	<version>5.22.0</version>
+	<version>5.22.1</version>
 	<packaging>pom</packaging>
 
         <parent>
           <groupId>org.eclipse.linuxtools</groupId>
           <artifactId>linuxtools-parent</artifactId>
-          <version>8.22.0</version>
+          <version>8.22.1</version>
         </parent>
 
 	<properties>

--- a/valgrind/org.eclipse.linuxtools.valgrind-feature/feature.xml
+++ b/valgrind/org.eclipse.linuxtools.valgrind-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.linuxtools.valgrind"
       label="%featureName"
-      version="8.22.0.qualifier"
+      version="8.22.1.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/valgrind/org.eclipse.linuxtools.valgrind-feature/pom.xml
+++ b/valgrind/org.eclipse.linuxtools.valgrind-feature/pom.xml
@@ -15,12 +15,12 @@
   <parent>
     <artifactId>linuxtools-valgrind-parent</artifactId>
     <groupId>org.eclipse.linuxtools.valgrind</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.valgrind</artifactId>
   <packaging>eclipse-feature</packaging>
-  <version>8.22.0-SNAPSHOT</version>
+  <version>8.22.1-SNAPSHOT</version>
 
   <name>Linux Tools Valgrind Tools Integration Feature</name>
 

--- a/valgrind/org.eclipse.linuxtools.valgrind.cachegrind.tests/pom.xml
+++ b/valgrind/org.eclipse.linuxtools.valgrind.cachegrind.tests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-valgrind-parent</artifactId>
     <groupId>org.eclipse.linuxtools.valgrind</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.valgrind.cachegrind.tests</artifactId>

--- a/valgrind/org.eclipse.linuxtools.valgrind.cachegrind/pom.xml
+++ b/valgrind/org.eclipse.linuxtools.valgrind.cachegrind/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-valgrind-parent</artifactId>
     <groupId>org.eclipse.linuxtools.valgrind</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.valgrind.cachegrind</artifactId>

--- a/valgrind/org.eclipse.linuxtools.valgrind.core.tests/pom.xml
+++ b/valgrind/org.eclipse.linuxtools.valgrind.core.tests/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>linuxtools-valgrind-parent</artifactId>
     <groupId>org.eclipse.linuxtools.valgrind</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.valgrind.core.tests</artifactId>

--- a/valgrind/org.eclipse.linuxtools.valgrind.core/pom.xml
+++ b/valgrind/org.eclipse.linuxtools.valgrind.core/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-valgrind-parent</artifactId>
     <groupId>org.eclipse.linuxtools.valgrind</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.valgrind.core</artifactId>

--- a/valgrind/org.eclipse.linuxtools.valgrind.doc/pom.xml
+++ b/valgrind/org.eclipse.linuxtools.valgrind.doc/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-valgrind-parent</artifactId>
     <groupId>org.eclipse.linuxtools.valgrind</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.valgrind.doc</artifactId>

--- a/valgrind/org.eclipse.linuxtools.valgrind.helgrind.tests/pom.xml
+++ b/valgrind/org.eclipse.linuxtools.valgrind.helgrind.tests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-valgrind-parent</artifactId>
     <groupId>org.eclipse.linuxtools.valgrind</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.valgrind.helgrind.tests</artifactId>

--- a/valgrind/org.eclipse.linuxtools.valgrind.helgrind/pom.xml
+++ b/valgrind/org.eclipse.linuxtools.valgrind.helgrind/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-valgrind-parent</artifactId>
     <groupId>org.eclipse.linuxtools.valgrind</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.valgrind.helgrind</artifactId>

--- a/valgrind/org.eclipse.linuxtools.valgrind.launch/pom.xml
+++ b/valgrind/org.eclipse.linuxtools.valgrind.launch/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-valgrind-parent</artifactId>
     <groupId>org.eclipse.linuxtools.valgrind</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.valgrind.launch</artifactId>

--- a/valgrind/org.eclipse.linuxtools.valgrind.massif.tests/pom.xml
+++ b/valgrind/org.eclipse.linuxtools.valgrind.massif.tests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-valgrind-parent</artifactId>
     <groupId>org.eclipse.linuxtools.valgrind</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.valgrind.massif.tests</artifactId>

--- a/valgrind/org.eclipse.linuxtools.valgrind.massif/pom.xml
+++ b/valgrind/org.eclipse.linuxtools.valgrind.massif/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-valgrind-parent</artifactId>
     <groupId>org.eclipse.linuxtools.valgrind</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.valgrind.massif</artifactId>

--- a/valgrind/org.eclipse.linuxtools.valgrind.memcheck.tests/pom.xml
+++ b/valgrind/org.eclipse.linuxtools.valgrind.memcheck.tests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-valgrind-parent</artifactId>
     <groupId>org.eclipse.linuxtools.valgrind</groupId>
-    <version>3.1.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.valgrind.memcheck.tests</artifactId>

--- a/valgrind/org.eclipse.linuxtools.valgrind.memcheck/pom.xml
+++ b/valgrind/org.eclipse.linuxtools.valgrind.memcheck/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-valgrind-parent</artifactId>
     <groupId>org.eclipse.linuxtools.valgrind</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.valgrind.memcheck</artifactId>

--- a/valgrind/org.eclipse.linuxtools.valgrind.remote-feature/feature.xml
+++ b/valgrind/org.eclipse.linuxtools.valgrind.remote-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.linuxtools.valgrind.remote"
       label="%featureName"
-      version="8.22.0.qualifier"
+      version="8.22.1.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/valgrind/org.eclipse.linuxtools.valgrind.remote-feature/pom.xml
+++ b/valgrind/org.eclipse.linuxtools.valgrind.remote-feature/pom.xml
@@ -15,12 +15,12 @@
   <parent>
     <artifactId>linuxtools-valgrind-parent</artifactId>
     <groupId>org.eclipse.linuxtools.valgrind</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.valgrind.remote</artifactId>
   <packaging>eclipse-feature</packaging>
-  <version>8.22.0-SNAPSHOT</version>
+  <version>8.22.1-SNAPSHOT</version>
 
   <name>Linux Tools Valgrind Tools Remote Integration Feature</name>
 

--- a/valgrind/org.eclipse.linuxtools.valgrind.tests/pom.xml
+++ b/valgrind/org.eclipse.linuxtools.valgrind.tests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-valgrind-parent</artifactId>
     <groupId>org.eclipse.linuxtools.valgrind</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.valgrind.tests</artifactId>

--- a/valgrind/org.eclipse.linuxtools.valgrind.ui.editor/pom.xml
+++ b/valgrind/org.eclipse.linuxtools.valgrind.ui.editor/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-valgrind-parent</artifactId>
     <groupId>org.eclipse.linuxtools.valgrind</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.valgrind.ui.editor</artifactId>

--- a/valgrind/org.eclipse.linuxtools.valgrind.ui.tests/pom.xml
+++ b/valgrind/org.eclipse.linuxtools.valgrind.ui.tests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-valgrind-parent</artifactId>
     <groupId>org.eclipse.linuxtools.valgrind</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.valgrind.ui.tests</artifactId>

--- a/valgrind/org.eclipse.linuxtools.valgrind.ui/pom.xml
+++ b/valgrind/org.eclipse.linuxtools.valgrind.ui/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>linuxtools-valgrind-parent</artifactId>
     <groupId>org.eclipse.linuxtools.valgrind</groupId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <artifactId>org.eclipse.linuxtools.valgrind.ui</artifactId>

--- a/valgrind/pom.xml
+++ b/valgrind/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.eclipse.linuxtools</groupId>
     <artifactId>linuxtools-parent</artifactId>
-    <version>8.22.0</version>
+    <version>8.22.1</version>
   </parent>
 
   <groupId>org.eclipse.linuxtools.valgrind</groupId>


### PR DESCRIPTION
- cherry-pick patch to use read timeout of 0 for Docker client copy
- bump up versions to 8.22.1
- remove PTP support from tests as PTP has been removed