### PR TITLE
Drop org.eclipse.ui.tests.harness from the Dockerfile LS tests

### DIFF
--- a/containers/org.eclipse.linuxtools.docker.editor.ls.tests/META-INF/MANIFEST.MF
+++ b/containers/org.eclipse.linuxtools.docker.editor.ls.tests/META-INF/MANIFEST.MF
@@ -16,5 +16,4 @@ Require-Bundle: org.eclipse.core.resources,
  org.eclipse.equinox.common,
  org.eclipse.ui.ide,
  org.eclipse.jface.text,
- org.eclipse.ui.tests.harness,
  org.eclipse.swt

--- a/containers/org.eclipse.linuxtools.docker.editor.ls.tests/src/org/eclipse/linuxtools/docker/editor/ls/tests/TestLanguageServers.java
+++ b/containers/org.eclipse.linuxtools.docker.editor.ls.tests/src/org/eclipse/linuxtools/docker/editor/ls/tests/TestLanguageServers.java
@@ -13,6 +13,7 @@
 package org.eclipse.linuxtools.docker.editor.ls.tests;
 
 import java.io.ByteArrayInputStream;
+import java.util.function.BooleanSupplier;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -20,12 +21,12 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IViewReference;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.preferences.ScopedPreferenceStore;
-import org.eclipse.ui.tests.harness.util.DisplayHelper;
 import org.eclipse.ui.texteditor.ITextEditor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -65,12 +66,28 @@ class TestLanguageServers {
 				.openEditor(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), file, "org.eclipse.ui.genericeditor.GenericEditor");
 		editor.getDocumentProvider().getDocument(editor.getEditorInput()).set("MAINTAINER alex");
 		Assertions.assertTrue(
-				DisplayHelper.waitForCondition(PlatformUI.getWorkbench().getDisplay(), 5000, () -> {
+				waitForCondition(PlatformUI.getWorkbench().getDisplay(), 5000, () -> {
 					try {
 						return file.findMarkers("org.eclipse.lsp4e.diagnostic", true, IResource.DEPTH_ZERO).length != 0;
 					} catch (CoreException e) {
 						return false;
 					}
 				}), "Diagnostic not published");
+	}
+
+	private static boolean waitForCondition(Display display, long timeoutMillis, BooleanSupplier condition) {
+		long deadline = System.currentTimeMillis() + timeoutMillis;
+		while (!condition.getAsBoolean()) {
+			if (System.currentTimeMillis() > deadline) {
+				return false;
+			}
+			if (!display.readAndDispatch()) {
+				// wake up periodically so the condition is re-checked even without UI events
+				display.timerExec(100, () -> {
+				});
+				display.sleep();
+			}
+		}
+		return true;
 	}
 }

--- a/releng/org.eclipse.linuxtools.target/linuxtools-latest.target
+++ b/releng/org.eclipse.linuxtools.target/linuxtools-latest.target
@@ -19,7 +19,6 @@
 <unit id="org.eclipse.pde.runtime" version="0.0.0"/>
 <unit id="org.eclipse.platform.ide" version="0.0.0"/>
 <unit id="org.eclipse.equinox.core.feature.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.ui.tests.harness" version="0.0.0"/>
 <unit id="org.objectweb.asm" version="0.0.0"/>
 <unit id="org.objectweb.asm.util" version="0.0.0"/>
 <unit id="org.objectweb.asm.tree" version="0.0.0"/>


### PR DESCRIPTION
org.eclipse.ui.tests.harness imports JUnit 5 (org.junit.jupiter.api [5,6), org.junit.platform.* [1.14,2)), which pulls JUnit 5.14/platform 1.14 into the test runtime alongside JUnit 6. Tycho's junit6 provider imports org.junit.platform.launcher without a version range, so it ends up wired to one platform version while ClassSelector is loaded from the other, and the run dies with an ArrayStoreException before any test is discovered.

The only thing used from the harness was DisplayHelper.waitForCondition, so inline an equivalent event-loop-pumping helper and drop the dependency. Nothing else uses the harness, so remove it from the target platform as well.

Assisted-by: Anthropic Claude Code (claude-fable-5)