### PR TITLE
Disable EGit auto-share in the ChangeLog SWTBot tests

### DIFF
--- a/changelog/org.eclipse.linuxtools.changelog.ui.tests/src/org/eclipse/linuxtools/changelog/ui/tests/swtbot/AbstractSWTBotTest.java
+++ b/changelog/org.eclipse.linuxtools.changelog.ui.tests/src/org/eclipse/linuxtools/changelog/ui/tests/swtbot/AbstractSWTBotTest.java
@@ -12,6 +12,9 @@
  *******************************************************************************/
 package org.eclipse.linuxtools.changelog.ui.tests.swtbot;
 
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.egit.core.Activator;
+import org.eclipse.egit.core.GitCorePreferences;
 import org.eclipse.linuxtools.changelog.ui.tests.utils.ProjectExplorer;
 import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
 import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
@@ -28,6 +31,13 @@ public abstract class AbstractSWTBotTest {
 
 	@BeforeAll
 	public static void beforeClass() {
+        // EGit automatically shares every new project that is located inside
+        // a git working tree, which the test workspace is when the build runs
+        // from a git checkout. That would share "unshared" test projects and
+        // map the GitTestProject to the enclosing repository, so turn it off
+        // before any test project is created.
+        InstanceScope.INSTANCE.getNode(Activator.PLUGIN_ID)
+                .putBoolean(GitCorePreferences.core_autoShareProjects, false);
         // delay click speed
         //System.setProperty("org.eclipse.swtbot.playback.delay", "200");
         bot = new SWTWorkbenchBot();


### PR DESCRIPTION
EGit connects every newly created project that sits inside a git working tree to the enclosing repository, from a job scheduled 100ms after the project appears. The test workspace lives under target/ of the git checkout, so depending on who wins the race the "not-shared" project of DisabledPrepareChangelogSWTBotTest gets shared (making "Prepare Changelog" visible) and the GitTestProject of PrepareChangelogSWTBotTest gets mapped to the enclosing linuxtools repository instead of its own, where the whole project is ignored and there is nothing to prepare a ChangeLog for, so the editor never opens.

Turn core_autoShareProjects off in AbstractSWTBotTest before any test project is created.

Assisted-by: Anthropic Claude Code (claude-fable-5)